### PR TITLE
Bugfix/union type

### DIFF
--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Lint Python
         run: |
           black --check --diff .
-          blackdoc --check --diff .
           ruff --exit-non-zero-on-fix .
           vermin --target=3.8- --no-tips --violations .
 

--- a/pylace/lace/engine.py
+++ b/pylace/lace/engine.py
@@ -416,7 +416,7 @@ class Engine:
 
         return df
 
-    def edit_cell(self, row: str | int, col: str | int, value):
+    def edit_cell(self, row: Union[str, int], col: Union[str, int], value):
         """
         Edit the value of a cell in the table
        

--- a/pylace/lace/engine.py
+++ b/pylace/lace/engine.py
@@ -417,9 +417,9 @@ class Engine:
         return df
 
     def edit_cell(self, row: Union[str, int], col: Union[str, int], value):
-        """
-        Edit the value of a cell in the table
-       
+        r"""
+        Edit the value of a cell in the table.
+
         Parameters
         ----------
         row: row index
@@ -431,7 +431,6 @@ class Engine:
 
         Examples
         --------
-
         Change a surprising value
 
         >>> from lace.examples import Animals
@@ -716,7 +715,7 @@ class Engine:
         state_ixs: Optional[list[int]] = None,
         scaled: bool = False,
     ) -> Union[None, float, pl.Series]:
-        """
+        r"""
         Compute the log likelihood.
 
         This function computes ``log p(values)`` or ``log p(values|given)``.


### PR DESCRIPTION
Fix for the failing Python lints. Remove `blackdoc` as a check, and fix the code incompatible with 3.8