### PR TITLE
Make timeout work in CLI

### DIFF
--- a/lace/bin/opt.rs
+++ b/lace/bin/opt.rs
@@ -139,7 +139,7 @@ pub struct RunArgs {
     #[clap(
         long,
         help = "Path to Engine run config Yaml",
-        conflicts_with_all = &["transitions", "col-alg", "row-alg", "timeout", "n-iters"],
+        conflicts_with_all = &["transitions", "col-alg", "row-alg", "n-iters"],
     )]
     pub run_config: Option<PathBuf>,
     /// An offset for the state IDs. The n state will be named

--- a/lace/bin/routes.rs
+++ b/lace/bin/routes.rs
@@ -62,6 +62,13 @@ fn new_engine(cmd: opt::RunArgs) -> i32 {
         update_config.checkpoint = cmd.checkpoint;
     };
 
+    // create timeout update handler
+    let timeout = Timeout::new(
+        cmd.timeout
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::MAX),
+    );
+
     // turn off mutability
     let update_config = update_config;
     let save_config = save_config;
@@ -105,10 +112,12 @@ fn new_engine(cmd: opt::RunArgs) -> i32 {
     };
 
     if cmd.quiet {
-        engine.update(update_config, CtrlC::new()).unwrap();
+        engine
+            .update(update_config, (timeout, CtrlC::new()))
+            .unwrap();
     } else {
         engine
-            .update(update_config, (ProgressBar::new(), CtrlC::new()))
+            .update(update_config, (timeout, ProgressBar::new(), CtrlC::new()))
             .unwrap();
     }
 


### PR DESCRIPTION
Running a new engine would ignore the timeout. The timeout also conflicted with the run config, which used to hold a timeout but does not anymore.