### PR TITLE
Parallelize state reads and writes w/ rayon

### DIFF
--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand_xoshiro 0.6.0",
+ "rayon",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/lace/lace_metadata/Cargo.toml
+++ b/lace/lace_metadata/Cargo.toml
@@ -21,6 +21,7 @@ rand_xoshiro = { version="0.6", features = ["serde1"] }
 thiserror = "1.0.19"
 once_cell = "1"
 hex = "0.4"
+rayon = "1.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/lace/lace_metadata/src/utils.rs
+++ b/lace/lace_metadata/src/utils.rs
@@ -353,13 +353,13 @@ pub(crate) fn save_states<P: AsRef<Path>>(
     state_ids: &[usize],
     ser_type: SerializedType,
 ) -> Result<(), Error> {
-    path_validator(path.as_ref())?;
+    use rayon::prelude::*;
+    let path = path.as_ref();
+    path_validator(path)?;
     states
-        .iter()
-        .zip(state_ids.iter())
-        .try_for_each(|(state, id)| {
-            save_state(path.as_ref(), state, *id, ser_type)
-        })
+        .par_iter()
+        .zip(state_ids.par_iter())
+        .try_for_each(|(state, id)| save_state(path, state, *id, ser_type))
 }
 
 pub(crate) fn save_data<P: AsRef<Path>>(

--- a/lace/src/examples/mod.rs
+++ b/lace/src/examples/mod.rs
@@ -103,6 +103,15 @@ impl Example {
         let n_states = 8;
 
         let paths = self.paths()?;
+        // delete the metadata entirely. this will get rid of extra states and
+        // diagnostics that we might have is we've previously worked on a branch
+        // with a higher number of example states.
+        {
+            let lacefile = paths.lace.as_path();
+            std::fs::remove_dir_all(lacefile)?;
+            std::fs::create_dir(lacefile)?;
+        }
+
         let codebook: Codebook = {
             let mut file = std::fs::File::open(&paths.codebook)?;
             let mut ser = String::new();

--- a/lace/src/examples/mod.rs
+++ b/lace/src/examples/mod.rs
@@ -108,8 +108,11 @@ impl Example {
         // with a higher number of example states.
         {
             let lacefile = paths.lace.as_path();
-            std::fs::remove_dir_all(lacefile)?;
-            std::fs::create_dir(lacefile)?;
+            // Can't remove a directory that doesn't exist
+            if lacefile.exists() {
+                std::fs::remove_dir_all(lacefile)?;
+                std::fs::create_dir(lacefile)?;
+            }
         }
 
         let codebook: Codebook = {

--- a/lace/src/examples/mod.rs
+++ b/lace/src/examples/mod.rs
@@ -103,8 +103,8 @@ impl Example {
         let n_states = 8;
 
         let paths = self.paths()?;
-        // delete the metadata entirely. this will get rid of extra states and
-        // diagnostics that we might have is we've previously worked on a branch
+        // Delete the metadata entirely. This will get rid of extra states and
+        // diagnostics that we might have if we've previously worked on a branch
         // with a higher number of example states.
         {
             let lacefile = paths.lace.as_path();

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "log",
  "once_cell",
  "rand_xoshiro",
+ "rayon",
  "serde",
  "serde_json",
  "serde_yaml",


### PR DESCRIPTION
Used rayon to read and write states in parallel when loading and saving metadata. The speedup for an 8-state model was about 4x, which is slower that I would have thought. Oh well -- better than nothing.