### PR TITLE
Auto check whether example metadata is up to date

### DIFF
--- a/pylace/.gitignore
+++ b/pylace/.gitignore
@@ -71,3 +71,7 @@ docs/source/generated
 
 # Pyenv
 .python-version
+
+# lace items
+*.lace
+checksum.json

--- a/pylace/lace/examples.py
+++ b/pylace/lace/examples.py
@@ -60,7 +60,7 @@ def write_hashes(hashes: dict, dst: Path):
 
 def read_hashes(src: Path):
     if src.exists():
-        with open(src, "r") as f:
+        with open(src) as f:
             return json.load(f)
     else:
         return None
@@ -70,7 +70,7 @@ def need_to_regen(hashes, current_hashes) -> bool:
     if current_hashes is None:
         return True
 
-    return any(hashes[k] != current_hashes[k] for k in hashes.keys())
+    return any(hashes[k] != current_hashes[k] for k in hashes)
 
 
 def yes_or_no(question):

--- a/pylace/lace/examples.py
+++ b/pylace/lace/examples.py
@@ -1,6 +1,6 @@
-import os
 import hashlib
 import json
+import os
 from pathlib import Path
 from shutil import rmtree
 

--- a/pylace/lace/examples.py
+++ b/pylace/lace/examples.py
@@ -1,3 +1,6 @@
+import os
+import hashlib
+import json
 from pathlib import Path
 from shutil import rmtree
 
@@ -10,11 +13,73 @@ DATASETS_PATH = Path(HERE, "resources", "datasets")
 ANIMALS = "animals"
 SATELLITES = "satellites"
 DATA_FILE = "data.csv"
+HASH_FILE = "checksum.json"
 CODEBOOK_FILE = "codebook.yaml"
 METADATA_DIR = "metadata.lace"
 ANIMALS_PATH = Path(DATASETS_PATH, ANIMALS)
 SATELLITES_PATH = Path(DATASETS_PATH, SATELLITES)
 EXAMPLE_PATHS = {SATELLITES: SATELLITES_PATH, ANIMALS: ANIMALS_PATH}
+
+QUIET_VAR = "PYLACE_EXAMPLES_QUIET"
+AUTOREGEN_VAR = "PYLACE_EXAMPLES_AUTO_REGEN"
+
+
+def md5checksum(filename: Path) -> str:
+    BUF_SIZE = 65536
+
+    md5 = hashlib.md5()
+
+    with open(filename, "rb") as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            md5.update(data)
+
+    return md5.hexdigest()
+
+
+def generate_metadata(data_src, dst, codebook, quiet=False):
+    if not quiet:
+        print(f'Generating metadata for data file "{data_src}"')
+
+    engine = Engine(
+        data_source=data_src,
+        codebook=codebook,
+        n_states=16,
+        rng_seed=1337,
+    )
+    engine.update(5000, quiet=quiet)
+    engine.save(dst)
+
+
+def write_hashes(hashes: dict, dst: Path):
+    with open(dst, "w") as f:
+        json.dump(hashes, f)
+
+
+def read_hashes(src: Path):
+    if src.exists():
+        with open(src, "r") as f:
+            return json.load(f)
+    else:
+        return None
+
+
+def need_to_regen(hashes, current_hashes) -> bool:
+    if current_hashes is None:
+        return True
+
+    return any(hashes[k] != current_hashes[k] for k in hashes.keys())
+
+
+def yes_or_no(question):
+    while "the answer is invalid":
+        reply = str(input(question + " (y/n): ")).lower().strip()
+        if reply[:1] == "y":
+            return True
+        if reply[:1] == "n":
+            return False
 
 
 class ExamplePaths:
@@ -26,20 +91,39 @@ class ExamplePaths:
             )
         base = EXAMPLE_PATHS[name]
         self.base = base
+        self.hash = Path(base, HASH_FILE)
         self.data = Path(base, DATA_FILE)
         self.codebook = Path(base, CODEBOOK_FILE)
         self.metadata = Path(base, METADATA_DIR)
 
+        quiet = bool(int(os.environ.get(QUIET_VAR, 0)))
+        auto_regen = bool(int(os.environ.get(AUTOREGEN_VAR, 0)))
+
+        # generate codebook and data hashes to monitor whether the examples have
+        # changed. If the examples have changed, the user will need to recreate
+        # the metadata.
+        hashes = {
+            "codebook": md5checksum(self.codebook),
+            "data": md5checksum(self.data),
+        }
+
+        current_hashes = read_hashes(self.hash)
+
         if not self.metadata.exists():
-            print(f'Generating metadata for data file "{self.data}"')
-            engine = Engine(
-                data_source=self.data,
-                codebook=self.codebook,
-                n_states=16,
-                rng_seed=1337,
-            )
-            engine.update(5000)
-            engine.save(self.metadata)
+            generate_metadata(self.data, self.metadata, self.codebook, quiet)
+            write_hashes(hashes, self.hash)
+        else:
+            if need_to_regen(hashes, current_hashes):
+                if auto_regen:
+                    generate_metadata(
+                        self.data, self.metadata, self.codebook, quiet
+                    )
+                    write_hashes(hashes, self.hash)
+                elif yes_or_no(f"{name} metadata is out of date. Regenerate?"):
+                    generate_metadata(
+                        self.data, self.metadata, self.codebook, quiet
+                    )
+                    write_hashes(hashes, self.hash)
 
 
 def delete_metadata(name: str):


### PR DESCRIPTION
To prevent local and CI metadata from getting out of wack I've done the following for pylace examples

Each time the user requests an example, md5 hashes will be generated for the codebook and dataset and checked against the hashes generated the last time metadata was generate. If the hashes do not match (or if there was no hash) the user will be prompted to re-run.

if you want to always rerun set `PYLACE_EXAMPLES_AUTO_REGEN=1`. 

if you do not want to see any output set `PYLACE_EXAMPLES_QUIET=1`