### PR TITLE
Publish all the necessary crates in the workspace

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -209,6 +209,18 @@ jobs:
       - name: Publish to Crates.io
         working-directory: lace
         run:
+          cargo publish --token "${CRATES_TOKEN}" -p lace_consts
+          cargo publish --token "${CRATES_TOKEN}" -p lace_data
+          cargo publish --token "${CRATES_TOKEN}" -p lace_utils
+
+          cargo publish --token "${CRATES_TOKEN}" -p lace_stats
+
+          cargo publish --token "${CRATES_TOKEN}" -p lace_cc
+          cargo publish --token "${CRATES_TOKEN}" -p lace_codebook
+          cargo publish --token "${CRATES_TOKEN}" -p lace_geweke
+
+          cargo publish --token "${CRATES_TOKEN}" -p lace_metadata
+
           cargo publish --token "${CRATES_TOKEN}" -p lace
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
`cargo publish` only supports publishing one crate at a time

To publish a whole workspace, you need to publish each package individually and you need to do it in dependency order