### PR TITLE
Fix dependency publish order

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -209,15 +209,17 @@ jobs:
       - name: Publish to Crates.io
         working-directory: lace
         run: |
+          cargo publish --token "${CRATES_TOKEN}" -p lace_utils
+
           cargo publish --token "${CRATES_TOKEN}" -p lace_consts
           cargo publish --token "${CRATES_TOKEN}" -p lace_data
-          cargo publish --token "${CRATES_TOKEN}" -p lace_utils
 
           cargo publish --token "${CRATES_TOKEN}" -p lace_stats
 
-          cargo publish --token "${CRATES_TOKEN}" -p lace_cc
           cargo publish --token "${CRATES_TOKEN}" -p lace_codebook
           cargo publish --token "${CRATES_TOKEN}" -p lace_geweke
+
+          cargo publish --token "${CRATES_TOKEN}" -p lace_cc
 
           cargo publish --token "${CRATES_TOKEN}" -p lace_metadata
 


### PR DESCRIPTION
I got the dependency deploy order incorrect initially because I did not realize
  that `cargo tree` does not, by default, show all the times a create shows up as a dependency