### PR TITLE
Bug/docs rs build - prepare for `0.1.1`

### DIFF
--- a/.github/scripts/run_code_in_mdfile.py
+++ b/.github/scripts/run_code_in_mdfile.py
@@ -21,7 +21,7 @@ def enumerate_string_lines(code):
         i+=1
     print("```", flush=True)
 
-def process_file(file, language):
+def process_file(file, language, version):
     print_filename(file)
     with open(file) as fh:
         result=subprocess.run(['codedown', language + '*'], stdin=fh, capture_output=True, text=True)
@@ -38,7 +38,7 @@ def process_file(file, language):
         elif args.language == 'rust':
             rust_script_contents=f"""//! ```cargo
         //! [dependencies]
-        //! lace = {{ path = ".", version="0.1.0" }}
+        //! lace = {{ path = ".", version="{version}" }}
         //! ```
         fn main() {{
         {code}
@@ -57,7 +57,7 @@ def process_file(file, language):
             return 1
 
 def execute_single_file(args):
-    return process_file(args.file, args.language)
+    return process_file(args.file, args.language, args.version)
 
 def process_dir(args):
     excluded_files=[]
@@ -77,7 +77,7 @@ def process_dir(args):
             if file_path in excluded_files:
                 continue
 
-            failures+=process_file(file_path, args.language)
+            failures+=process_file(file_path, args.language, args.version)
 
     return failures
 
@@ -87,11 +87,13 @@ subparsers = parser.add_subparsers(help="Must give a subcommand")
 single_file_command=subparsers.add_parser("single-file", help="Test single file")
 single_file_command.add_argument('language')
 single_file_command.add_argument('file')
+single_file_command.add_argument("version") # Version isn't necessary for python, so this could be improved
 single_file_command.set_defaults(func=execute_single_file)
 
 directory_command=subparsers.add_parser("directory", help="Test on all MD files in a directory")
 directory_command.add_argument("language")
 directory_command.add_argument("dir")
+directory_command.add_argument("version")
 directory_command.add_argument("--exclusion-file", type=argparse.FileType())
 directory_command.set_defaults(func=process_dir)
 

--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -221,8 +221,9 @@ jobs:
         env:
           FORCE_COLOR: 1
         run: |
-            pip install termcolor
-            python3 .github/scripts/run_code_in_mdfile.py directory python book --exclusion-file .github/resources/mdbook_exclusions.txt
+          pip install termcolor yq
+          NEW_VERSION=$(tomlq -r .package.version < pylace/Cargo.toml)
+          python3 .github/scripts/run_code_in_mdfile.py directory python book $NEW_VERSION --exclusion-file .github/resources/mdbook_exclusions.txt
 
   test-mdbook-build:
     name: Test MDBook Building

--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -185,8 +185,9 @@ jobs:
         env:
           FORCE_COLOR: 1
         run: |
-          pip install termcolor
-          python3 .github/scripts/run_code_in_mdfile.py directory rust book --exclusion-file .github/resources/mdbook_exclusions.txt
+          pip install termcolor yq
+          NEW_VERSION=$(tomlq -r .package.version < lace/Cargo.toml)
+          python3 .github/scripts/run_code_in_mdfile.py directory rust book $NEW_VERSION --exclusion-file .github/resources/mdbook_exclusions.txt
 
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [rust-0.1.1] - 2023-05-31
+
+### Fixed
+
+Documentation fixes
+Benchmark tests now work properly
+
 ## [python-0.1.0] - 2023-04-24
 
 ### Added
@@ -20,6 +27,7 @@ Initial release on [PyPi](https://pypi.org/)
 Initial release on [crates.io](https://crates.io/)
 
 [unreleased]: https://github.com/promised-ai/lace/compare/python-0.1.0...HEAD
+[rust-0.1.1]: https://github.com/promised-ai/lace/compare/rust-0.1.1...rust-0.1.0
 [python-0.1.0]: https://github.com/promised-ai/lace/releases/tag/python-0.1.0
 [rust-0.1.0]: https://github.com/promised-ai/lace/releases/tag/rust-0.1.0
 

--- a/book/lace_preprocess_mdbook_yaml/Cargo.toml
+++ b/book/lace_preprocess_mdbook_yaml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_preprocess_mdbook_yaml"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -18,8 +18,8 @@ path = "src/main.rs"
 anyhow = "1.0"
 clap = "4.2"
 env_logger = "0.9"
-lace_codebook = { path = "../../lace/lace_codebook", version = "0.1.0" }
-lace_stats = { path = "../../lace/lace_stats", version = "0.1.0" }
+lace_codebook = { path = "../../lace/lace_codebook", version = "0.1.1" }
+lace_stats = { path = "../../lace/lace_stats", version = "0.1.1" }
 log = "0.4"
 mdbook = "0.4"
 pulldown-cmark = { version = "0.9", default-features = false }

--- a/book/lace_preprocess_mdbook_yaml/Cargo.toml
+++ b/book/lace_preprocess_mdbook_yaml/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "SSPL-1.0"
 homepage = "https://www.lace.dev/"
 repository = "https://github.com/promised-ai/lace"
-description = "Miscellaneous utilities for Lace and shared libraries"
+description = "Utility to check YAML serializations in the Lace MDBook"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "bincode",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "flate2",
  "indoc 2.0.1",
@@ -1207,14 +1207,14 @@ dependencies = [
 
 [[package]]
 name = "lace_consts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rv",
 ]
 
 [[package]]
 name = "lace_data"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "lace_geweke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "indicatif",
  "lace_stats",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "dirs",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "lace_stats"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "criterion",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "lace_utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "rand",

--- a/lace/Cargo.toml
+++ b/lace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 build = "build.rs"
 edition = "2021"
@@ -35,14 +35,14 @@ name = "lace"
 path = "bin/main.rs"
 
 [dependencies]
-lace_cc = { path = "lace_cc", version = "0.1.0" }
-lace_utils = { path = "lace_utils", version = "0.1.0" }
-lace_stats = { path = "lace_stats", version = "0.1.0" }
-lace_codebook = { path = "lace_codebook", version = "0.1.0" }
-lace_geweke = { path = "lace_geweke", version = "0.1.0" }
-lace_consts = { path = "lace_consts", version = "0.1.0" }
-lace_data = { path = "lace_data", version = "0.1.0" }
-lace_metadata = { path = "lace_metadata", version = "0.1.0" }
+lace_cc = { path = "lace_cc", version = "0.1.1" }
+lace_utils = { path = "lace_utils", version = "0.1.1" }
+lace_stats = { path = "lace_stats", version = "0.1.1" }
+lace_codebook = { path = "lace_codebook", version = "0.1.1" }
+lace_geweke = { path = "lace_geweke", version = "0.1.1" }
+lace_consts = { path = "lace_consts", version = "0.1.1" }
+lace_data = { path = "lace_data", version = "0.1.1" }
+lace_metadata = { path = "lace_metadata", version = "0.1.1" }
 dirs = "4"
 itertools = "0.10.3"
 num = "0.4"

--- a/lace/build.rs
+++ b/lace/build.rs
@@ -28,21 +28,28 @@ fn copy_resources(
 }
 
 fn main() {
-    // Copy Examples
-    let examples_dir: PathBuf = dirs::data_dir()
-        .map(|dir| dir.join("lace").join("examples"))
-        .expect("Could not find data dir.");
+    // DOCS_RS indicates that you are building for the website `https://docs.rs`
+    if std::env::var("DOCS_RS").is_err() {
+        for (key, val) in std::env::vars() {
+            println!("ENV: {key} == {val}");
+        }
 
-    let resources_dir = Path::new("resources").join("datasets");
+        // Copy Examples
+        let examples_dir: PathBuf = dirs::data_dir()
+            .map(|dir| dir.join("lace").join("examples"))
+            .expect("Could not find data dir.");
 
-    std::fs::create_dir_all(&examples_dir)
-        .expect("Could not create examples dir.");
+        let resources_dir = Path::new("resources").join("datasets");
 
-    for dataset_name in DATASET_NAMES {
-        copy_resources(
-            dataset_name,
-            examples_dir.as_path(),
-            resources_dir.as_path(),
-        )
+        std::fs::create_dir_all(&examples_dir)
+            .expect("Could not create examples dir.");
+
+        for dataset_name in DATASET_NAMES {
+            copy_resources(
+                dataset_name,
+                examples_dir.as_path(),
+                resources_dir.as_path(),
+            )
+        }
     }
 }

--- a/lace/lace_cc/Cargo.toml
+++ b/lace/lace_cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_cc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 exclude = ["tests/*", "resources/test/*", "target/*"]
@@ -10,12 +10,12 @@ repository = "https://github.com/promised-ai/lace"
 description = "Core of the Lace cross-categorization engine library"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.0" }
-lace_stats = { path = "../lace_stats", version = "0.1.0" }
-lace_geweke = { path = "../lace_geweke", version = "0.1.0" }
-lace_consts = { path = "../lace_consts", version = "0.1.0" }
-lace_data = { path = "../lace_data", version = "0.1.0" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.0" }
+lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_stats = { path = "../lace_stats", version = "0.1.1" }
+lace_geweke = { path = "../lace_geweke", version = "0.1.1" }
+lace_consts = { path = "../lace_consts", version = "0.1.1" }
+lace_data = { path = "../lace_data", version = "0.1.1" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.1" }
 rand = {version="0.8", features=["serde1"]}
 rayon = "1.5"
 serde = { version = "1", features = ["derive"] }

--- a/lace/lace_codebook/Cargo.toml
+++ b/lace/lace_codebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_codebook"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised.ai"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,10 +9,10 @@ repository = "https://github.com/promised-ai/lace"
 description = "Contains the Lace codebook specification as well as utilities for generating defaults"
 
 [dependencies]
-lace_consts = { path = "../lace_consts", version = "0.1.0" }
-lace_stats = { path = "../lace_stats", version = "0.1.0" }
-lace_utils = { path = "../lace_utils", version = "0.1.0" }
-lace_data = { path = "../lace_data", version = "0.1.0" }
+lace_consts = { path = "../lace_consts", version = "0.1.1" }
+lace_stats = { path = "../lace_stats", version = "0.1.1" }
+lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_data = { path = "../lace_data", version = "0.1.1" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"
 maplit = "1"

--- a/lace/lace_consts/Cargo.toml
+++ b/lace/lace_consts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_consts"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promied AI"]
 edition = "2021"
 license = "SSPL-1.0"

--- a/lace/lace_data/Cargo.toml
+++ b/lace/lace_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_data"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/promised-ai/lace"
 description = "Data definitions and data container definitions for Lace"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.0" }
+lace_utils = { path = "../lace_utils", version = "0.1.1" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.19"
 regex = "1"

--- a/lace/lace_geweke/Cargo.toml
+++ b/lace/lace_geweke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_geweke"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/promised-ai/lace"
 description = "Geweke tester for Lace"
 
 [dependencies]
-lace_stats = { path = "../lace_stats", version = "0.1.0" }
-lace_utils = { path = "../lace_utils", version = "0.1.0" }
+lace_stats = { path = "../lace_stats", version = "0.1.1" }
+lace_utils = { path = "../lace_utils", version = "0.1.1" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"
 indicatif = "0.17"

--- a/lace/lace_metadata/Cargo.toml
+++ b/lace/lace_metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_metadata"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,10 +9,10 @@ repository = "https://github.com/promised-ai/lace"
 description = "Archive of the metadata (savefile) formats for Lace. In charge of versioning and conversion."
 
 [dependencies]
-lace_stats = { path = "../lace_stats", version = "0.1.0" }
-lace_data = { path = "../lace_data", version = "0.1.0" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.0" }
-lace_cc = { path = "../lace_cc", version = "0.1.0" }
+lace_stats = { path = "../lace_stats", version = "0.1.1" }
+lace_data = { path = "../lace_data", version = "0.1.1" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.1" }
+lace_cc = { path = "../lace_cc", version = "0.1.1" }
 dirs = "4"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"

--- a/lace/lace_stats/Cargo.toml
+++ b/lace/lace_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_stats"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,9 +9,9 @@ repository = "https://github.com/promised-ai/lace"
 description = "Contains component model and hyperprior specifications"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.0" }
-lace_consts = { path = "../lace_consts", version = "0.1.0" }
-lace_data = { path = "../lace_data", version = "0.1.0" }
+lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_consts = { path = "../lace_consts", version = "0.1.1" }
+lace_data = { path = "../lace_data", version = "0.1.1" }
 special = "0.8"
 rand = {version="0.8", features=["serde1"]}
 rand_xoshiro = "0.6"

--- a/lace/lace_utils/Cargo.toml
+++ b/lace/lace_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_utils"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"

--- a/lace/src/interface/engine/builder.rs
+++ b/lace/src/interface/engine/builder.rs
@@ -76,7 +76,7 @@ impl Builder {
         self
     }
 
-    // Build the `Engine`; consume the `EngineBuilder`.
+    // Build the `Engine`; consume the `Builder`.
     pub fn build(self) -> Result<Engine, BuildEngineError> {
         let nstates = self.n_states.unwrap_or(DEFAULT_NSTATES);
 

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "clap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "enum_dispatch",
  "indicatif",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "flate2",
  "lace_consts",
@@ -993,14 +993,14 @@ dependencies = [
 
 [[package]]
 name = "lace_consts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rv",
 ]
 
 [[package]]
 name = "lace_data"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lace_utils",
  "regex",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "lace_geweke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "indicatif",
  "lace_stats",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "dirs",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "lace_stats"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "itertools",
  "lace_consts",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "lace_utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "rand",
 ]

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -9,7 +9,7 @@ name = "lace"
 crate-type = ["cdylib"]
 
 [dependencies]
-lace = { path = "../lace", version="0.1.0" }
+lace = { path = "../lace", version="0.1.1" }
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
 pyo3 = { version = "0.18", features = ["extension-module"] }


### PR DESCRIPTION
Some changes for a rust `0.1.1`. Some notes:

* I bumped the version of all the `lace` rust crates; I think this is how Polars does it
* I did not bump the version of `pylace`...maybe I should? But I wasn't planning on releasing it
* The fix for [docs.rs](https://docs.rs/) is pretty simple, and won't stop the file move when building the lace docs in other places, like locally.
* I added a fix for the MDBook checker to follow the version number correctly