### PR TITLE
Be consistent w/ index column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [python-0.1.2] - 2023-06-07
+
+### Added
+- Allow index column name to be a case-insensitive variant of `ID` or `Index`
+    across `Engine` methods
+
+## [rust-0.1.2] - 2023-06-07
+
+### Added
+- Allow index column name to be a case-insensitive variant of `ID` or `Index`
+
 ## [rust-0.1.1] - 2023-05-31
 
 ### Fixed
 
-Documentation fixes
-Benchmark tests now work properly
+- Documentation fixes
+- Benchmark tests now work properly
 
 ## [python-0.1.0] - 2023-04-24
 

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "bincode",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "criterion",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "flate2",
  "indoc 2.0.1",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "lace_data"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "criterion",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "lace_geweke"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "indicatif",
  "lace_stats",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "dirs",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "lace_stats"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "criterion",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "lace_utils"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "approx",
  "rand",

--- a/lace/Cargo.toml
+++ b/lace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 build = "build.rs"
 edition = "2021"
@@ -35,14 +35,14 @@ name = "lace"
 path = "bin/main.rs"
 
 [dependencies]
-lace_cc = { path = "lace_cc", version = "0.1.1" }
-lace_utils = { path = "lace_utils", version = "0.1.1" }
-lace_stats = { path = "lace_stats", version = "0.1.1" }
-lace_codebook = { path = "lace_codebook", version = "0.1.1" }
-lace_geweke = { path = "lace_geweke", version = "0.1.1" }
+lace_cc = { path = "lace_cc", version = "0.1.2" }
+lace_utils = { path = "lace_utils", version = "0.1.2" }
+lace_stats = { path = "lace_stats", version = "0.1.2" }
+lace_codebook = { path = "lace_codebook", version = "0.1.2" }
+lace_geweke = { path = "lace_geweke", version = "0.1.2" }
 lace_consts = { path = "lace_consts", version = "0.1.1" }
-lace_data = { path = "lace_data", version = "0.1.1" }
-lace_metadata = { path = "lace_metadata", version = "0.1.1" }
+lace_data = { path = "lace_data", version = "0.1.2" }
+lace_metadata = { path = "lace_metadata", version = "0.1.2" }
 dirs = "4"
 itertools = "0.10.3"
 num = "0.4"

--- a/lace/lace_cc/Cargo.toml
+++ b/lace/lace_cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_cc"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 exclude = ["tests/*", "resources/test/*", "target/*"]
@@ -10,12 +10,12 @@ repository = "https://github.com/promised-ai/lace"
 description = "Core of the Lace cross-categorization engine library"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.1" }
-lace_stats = { path = "../lace_stats", version = "0.1.1" }
-lace_geweke = { path = "../lace_geweke", version = "0.1.1" }
+lace_utils = { path = "../lace_utils", version = "0.1.2" }
+lace_stats = { path = "../lace_stats", version = "0.1.2" }
+lace_geweke = { path = "../lace_geweke", version = "0.1.2" }
 lace_consts = { path = "../lace_consts", version = "0.1.1" }
 lace_data = { path = "../lace_data", version = "0.1.1" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.1" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.2" }
 rand = {version="0.8", features=["serde1"]}
 rayon = "1.5"
 serde = { version = "1", features = ["derive"] }

--- a/lace/lace_codebook/Cargo.toml
+++ b/lace/lace_codebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_codebook"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised.ai"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -10,9 +10,9 @@ description = "Contains the Lace codebook specification as well as utilities for
 
 [dependencies]
 lace_consts = { path = "../lace_consts", version = "0.1.1" }
-lace_stats = { path = "../lace_stats", version = "0.1.1" }
-lace_utils = { path = "../lace_utils", version = "0.1.1" }
-lace_data = { path = "../lace_data", version = "0.1.1" }
+lace_stats = { path = "../lace_stats", version = "0.1.2" }
+lace_utils = { path = "../lace_utils", version = "0.1.2" }
+lace_data = { path = "../lace_data", version = "0.1.2" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"
 maplit = "1"

--- a/lace/lace_codebook/src/data.rs
+++ b/lace/lace_codebook/src/data.rs
@@ -438,7 +438,7 @@ fn series_to_colmd(
 
 fn rownames_from_index(id_srs: &Series) -> Result<RowNameList, CodebookError> {
     // this should not be able to happen due to user error, so we panic
-    assert_eq!(id_srs.name().to_lowercase(), "id");
+    assert!(lace_utils::is_index_col(id_srs.name()));
 
     if id_srs.null_count() > 0 {
         return Err(CodebookError::NullValuesInIndex);
@@ -459,7 +459,7 @@ pub fn df_to_codebook(
         let mut row_names_opt: Option<RowNameList> = None;
         let mut col_metadata = Vec::with_capacity(df.shape().1);
         for srs in df.get_columns().iter() {
-            if srs.name().to_lowercase() == "id" {
+            if lace_utils::is_index_col(srs.name()) {
                 if row_names_opt.is_some() {
                     return Err(CodebookError::MultipleIdColumns);
                 }

--- a/lace/lace_codebook/src/value_map.rs
+++ b/lace/lace_codebook/src/value_map.rs
@@ -83,7 +83,7 @@ impl ValueMap {
     pub fn len(&self) -> usize {
         match self {
             Self::String(inner) => inner.len(),
-            Self::U8(k) => *k as usize,
+            Self::U8(k) => *k,
             Self::Bool => 2,
         }
     }

--- a/lace/lace_data/Cargo.toml
+++ b/lace/lace_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_data"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/promised-ai/lace"
 description = "Data definitions and data container definitions for Lace"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_utils = { path = "../lace_utils", version = "0.1.2" }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0.19"
 regex = "1"

--- a/lace/lace_geweke/Cargo.toml
+++ b/lace/lace_geweke/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_geweke"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,8 +9,8 @@ repository = "https://github.com/promised-ai/lace"
 description = "Geweke tester for Lace"
 
 [dependencies]
-lace_stats = { path = "../lace_stats", version = "0.1.1" }
-lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_stats = { path = "../lace_stats", version = "0.1.2" }
+lace_utils = { path = "../lace_utils", version = "0.1.2" }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"
 indicatif = "0.17"

--- a/lace/lace_metadata/Cargo.toml
+++ b/lace/lace_metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_metadata"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,10 +9,10 @@ repository = "https://github.com/promised-ai/lace"
 description = "Archive of the metadata (savefile) formats for Lace. In charge of versioning and conversion."
 
 [dependencies]
-lace_stats = { path = "../lace_stats", version = "0.1.1" }
-lace_data = { path = "../lace_data", version = "0.1.1" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.1" }
-lace_cc = { path = "../lace_cc", version = "0.1.1" }
+lace_stats = { path = "../lace_stats", version = "0.1.2" }
+lace_data = { path = "../lace_data", version = "0.1.2" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.2" }
+lace_cc = { path = "../lace_cc", version = "0.1.2" }
 dirs = "4"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"

--- a/lace/lace_stats/Cargo.toml
+++ b/lace/lace_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_stats"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -9,9 +9,9 @@ repository = "https://github.com/promised-ai/lace"
 description = "Contains component model and hyperprior specifications"
 
 [dependencies]
-lace_utils = { path = "../lace_utils", version = "0.1.1" }
+lace_utils = { path = "../lace_utils", version = "0.1.2" }
 lace_consts = { path = "../lace_consts", version = "0.1.1" }
-lace_data = { path = "../lace_data", version = "0.1.1" }
+lace_data = { path = "../lace_data", version = "0.1.2" }
 special = "0.8"
 rand = {version="0.8", features=["serde1"]}
 rand_xoshiro = "0.6"

--- a/lace/lace_stats/src/sample_error.rs
+++ b/lace/lace_stats/src/sample_error.rs
@@ -151,7 +151,7 @@ impl SampleError<u8> for Mixture<Categorical> {
         let cdf = {
             let mut cdf = vec![0.0; k];
             let incr = (xs.len() as f64).recip();
-            xs.iter().for_each(|&x| cdf[(x as usize)] += incr);
+            xs.iter().for_each(|&x| cdf[x as usize] += incr);
 
             for ix in 1..k {
                 cdf[ix] += cdf[ix - 1];

--- a/lace/lace_utils/Cargo.toml
+++ b/lace/lace_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_utils"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"

--- a/lace/lace_utils/src/misc.rs
+++ b/lace/lace_utils/src/misc.rs
@@ -4,6 +4,11 @@ use std::mem::swap;
 use std::ops::AddAssign;
 use std::str::FromStr;
 
+pub fn is_index_col(col_name: &str) -> bool {
+    let lower = col_name.to_lowercase();
+    lower == "id" || lower == "index"
+}
+
 pub trait MinMax {
     type Inner: PartialOrd;
     /// Simultaneously compute the min and max of items in an Iterator. Returns
@@ -606,5 +611,20 @@ mod tests {
         let unused = unused_components(k, &asgn_vec);
         assert_eq!(unused[0], 3);
         assert_eq!(unused[1], 1);
+    }
+
+    #[test]
+    fn is_index_col_tests() {
+        assert!(is_index_col("ID"));
+        assert!(is_index_col("id"));
+        assert!(is_index_col("iD"));
+        assert!(is_index_col("Id"));
+        assert!(is_index_col("Index"));
+        assert!(is_index_col("index"));
+
+        assert!(!is_index_col("idindex"));
+        assert!(!is_index_col("indexid"));
+        assert!(!is_index_col(""));
+        assert!(!is_index_col("icecream"));
     }
 }

--- a/lace/src/data/error.rs
+++ b/lace/src/data/error.rs
@@ -12,8 +12,8 @@ pub enum CsvParseError {
     /// The CSV file had no columns
     #[error("The csv contained no columns")]
     NoColumns,
-    /// The first column must be named "ID" or "id"
-    #[error("The first csv column must be named 'ID' or 'id'")]
+    /// The first column must be named "ID" or "Index
+    #[error("The first csv column must be named a case-insensitive variant of either 'ID' or 'Index'")]
     FirstColumnNotNamedId,
     /// There are one or more columns that are in the CSV, but not the codebook
     #[error("One or more columns appear in the csv that do not appear in the codebook")]

--- a/lace/src/data/init.rs
+++ b/lace/src/data/init.rs
@@ -202,7 +202,7 @@ pub fn df_to_col_models<R: rand::Rng>(
         if id_cols.is_empty() {
             Err(DataParseError::NoIDColumn)
         } else if id_cols.len() > 1 {
-            Err(DataParseError::MultipleIdColumns)
+            Err(DataParseError::MultipleIdColumns(id_cols))
         } else {
             Ok(id_cols.pop().expect("Should have had one ID column"))
         }

--- a/lace/src/interface/engine/data.rs
+++ b/lace/src/interface/engine/data.rs
@@ -753,7 +753,7 @@ pub(crate) fn maybe_add_categories<R: RowIndex, C: ColumnIndex>(
                                 }
                                 .map(|value| {
                                     if let Some(x) = value {
-                                        let x = utils::category_to_u8(&x, ix, engine.codebook()).unwrap();
+                                        let x = utils::category_to_u8(x, ix, engine.codebook()).unwrap();
                                         // If there was a value to be inserted, then
                                         // we add that as the "requested" maximum
                                         // support.

--- a/lace/src/interface/engine/error.rs
+++ b/lace/src/interface/engine/error.rs
@@ -29,8 +29,8 @@ pub enum DataParseError {
     #[error("No 'ID' column")]
     NoIDColumn,
     /// There is more than one ID column
-    #[error("Multiple ID columns")]
-    MultipleIdColumns,
+    #[error("Multiple ID columns: {0:?}")]
+    MultipleIdColumns(Vec<String>),
     /// There is a column type in the codebook that is not supported for loading
     /// externally
     #[error("Column `{col_name}` has type `{col_type}`, which is unsupported for external data sources")]

--- a/lace/src/interface/engine/error.rs
+++ b/lace/src/interface/engine/error.rs
@@ -28,6 +28,9 @@ pub enum DataParseError {
     /// There is no `ID` column in the dataset
     #[error("No 'ID' column")]
     NoIDColumn,
+    /// There is more than one ID column
+    #[error("Multiple ID columns")]
+    MultipleIdColumns,
     /// There is a column type in the codebook that is not supported for loading
     /// externally
     #[error("Column `{col_name}` has type `{col_type}`, which is unsupported for external data sources")]

--- a/lace/src/interface/oracle/utils.rs
+++ b/lace/src/interface/oracle/utils.rs
@@ -80,14 +80,14 @@ pub(crate) fn pre_process_datum(
         value_map
             .ix(&cat)
             .map(|u| Datum::Categorical(Category::U8(u as u8)))
-            .ok_or_else(|| IndexError::CategoryIndexNotFound { col_ix, cat })
+            .ok_or(IndexError::CategoryIndexNotFound { col_ix, cat })
     } else {
         Ok(x)
     }
 }
 
 pub(crate) fn pre_process_row(
-    row: &Vec<Datum>,
+    row: &[Datum],
     col_ixs: &[usize],
     codebook: &Codebook,
 ) -> Vec<Datum> {

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -1845,6 +1845,7 @@ version = "0.1.0"
 dependencies = [
  "arrow2",
  "lace",
+ "lace_utils",
  "polars",
  "pyo3",
  "rand",

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylace"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "SSPL-1.0"
 
@@ -9,8 +9,8 @@ name = "lace"
 crate-type = ["cdylib"]
 
 [dependencies]
-lace = { path = "../lace", version="0.1.1" }
-lace_utils = { path = "../lace/lace_utils", version="0.1.1" }
+lace = { path = "../lace", version="0.1.2" }
+lace_utils = { path = "../lace/lace_utils", version="0.1.2" }
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
 pyo3 = { version = "0.18", features = ["extension-module"] }

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lace = { path = "../lace", version="0.1.1" }
+lace_utils = { path = "../lace/lace_utils", version="0.1.1" }
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
 pyo3 = { version = "0.18", features = ["extension-module"] }

--- a/pylace/pyproject.toml
+++ b/pylace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pylace"
-version = "0.1.0"
+version = "0.1.1"
 description = "A probabalistic programming ML tool for science"
 requires-python = ">=3.8"
 classifiers = [

--- a/pylace/src/utils.rs
+++ b/pylace/src/utils.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use lace::codebook::{Codebook, ColType, ValueMap};
+use lace::codebook::{Codebook, ValueMap};
 use lace::{ColumnIndex, Datum, FType, Given, OracleT};
+use lace_utils::is_index_col;
 use polars::frame::DataFrame;
 use polars::prelude::NamedFrom;
 use polars::series::Series;
@@ -540,7 +541,6 @@ fn values_to_data(
     data.iter()
         .map(|row_any| {
             let row_dict: &PyDict = row_any.downcast().unwrap();
-
             process_row_dict(row_dict, col_ixs, engine)
         })
         .collect()
@@ -559,44 +559,46 @@ fn df_to_values(
     indexer: &Indexer,
     engine: &lace::Engine,
 ) -> PyResult<DataFrameComponents> {
-    let row_names = if df.hasattr("index")? {
-        let index = df.getattr("index")?;
-        srs_to_strings(index).ok()
-    } else {
-        df.call_method1("__getitem__", ("index",))
-            .and_then(srs_to_strings)
-            .ok()
-    };
-
     Python::with_gil(|py| {
-        let (columns, data) = {
+        let (columns, data, row_names) = {
             let columns = df.getattr("columns").unwrap();
             if columns.get_type().name().unwrap().contains("Index") {
                 // Is a Pandas dataframe
+                let index = df.getattr("index")?;
+                let row_names = srs_to_strings(index).ok();
+
                 let cols =
                     columns.call_method0("tolist").unwrap().to_object(py);
                 let kwargs = PyDict::new(py);
                 kwargs.set_item("orient", "records").unwrap();
                 let data = df.call_method("to_dict", (), Some(kwargs)).unwrap();
-                (cols, data)
+                (cols, data, row_names)
             } else {
                 // Is a Polars dataframe
                 let list = columns.downcast::<PyList>().unwrap();
-                let has_index = list
+                let index_col_name = list
                     .iter()
-                    .any(|s| s.extract::<&str>().unwrap() == "index");
+                    .map(|s| s.extract::<&str>().unwrap())
+                    .find(|s| is_index_col(s));
 
-                let df = if has_index {
+                let (df, row_names) = if let Some(index_name) = index_col_name {
                     // remove the index column label
-                    list.call_method1("remove", ("index",)).unwrap();
+                    list.call_method1("remove", (index_name,)).unwrap();
+                    // Get the indices from the index if it exists
+                    let row_names = df
+                        .call_method1("__getitem__", (index_name,))
+                        .and_then(srs_to_strings)
+                        .ok();
                     // remove the index column from the data
-                    df.call_method1("drop", ("index",)).unwrap()
+                    let df = df.call_method1("drop", (index_name,)).unwrap();
+
+                    (df, row_names)
                 } else {
-                    df
+                    (df, None)
                 };
 
                 let data = df.call_method0("to_dicts").unwrap();
-                (list.to_object(py), data)
+                (list.to_object(py), data, row_names)
             }
         };
 


### PR DESCRIPTION
Previously: lace required the index column to be names a case- insensitive variant of "ID", but pylace required "index". Now there is a function in lace_utils that checks whether a string is "ID" or "index" so either is allowed. This also reduces repetition of `== "id"` and such, which is error prone.