### PR TITLE
BUGFIX pylace append_rows claims duplicate indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [python-0.1.2] - 2023-06-07
+## [python-0.1.2] - 2023-06-09
+
+### Fixed
+
+- `Engine.append_rows` would incorrectly raise an exception stating that
+    duplicate indices were found in polars DataFrame
+
+## [python-0.1.1] - 2023-06-07
 
 ### Added
 - Allow index column name to be a case-insensitive variant of `ID` or `Index`

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylace"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "SSPL-1.0"
 

--- a/pylace/pyproject.toml
+++ b/pylace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pylace"
-version = "0.1.1"
+version = "0.1.2"
 description = "A probabalistic programming ML tool for science"
 requires-python = ">=3.8"
 classifiers = [

--- a/pylace/src/utils.rs
+++ b/pylace/src/utils.rs
@@ -593,7 +593,7 @@ fn df_to_values(
 
                         if index_col_names.is_empty() {
                             Ok(None)
-                        } else if index_col_names.len() > 0 {
+                        } else if index_col_names.len() > 1 {
                             Err(PyValueError::new_err(format!(
                             "There should only be one index column, but found \
                             the following: {:?}", index_col_names)))


### PR DESCRIPTION
There was a bug in which pylace.Engine.append_rows would incorrectly complain about polars.DataFrames having more than one index column. This was a results of a `> 0` instead of `> 1`. My bad.