### PR TITLE
Update to publishing process

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -213,25 +213,29 @@ jobs:
         run: |
           pip install yq
           DEPLOYING_VERSION=$(echo "$NEW_VERSION" | perl -lpe 's/^rust-//')
-          find . -name Cargo.toml -exec tomlq -r .package.version {} \; | xargs -n 1 test "$DEPLOYING_VERSION" =
-
-      - name: Publish to Crates.io
+          MAIN_VERSION=$(tomlq -r .package.version Cargo.toml)
+          test "$DEPLOYING_VERSION" = "$MAIN_VERSION"
+      - name: Install dependencies
+        run: cargo install cargo-crate
+      - name: Publish Updated Crates to Crates.io
         working-directory: lace
-        run: |
-          cargo publish --token "${CRATES_TOKEN}" -p lace_utils
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace_consts
-          cargo publish --token "${CRATES_TOKEN}" -p lace_data
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace_stats
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace_codebook
-          cargo publish --token "${CRATES_TOKEN}" -p lace_geweke
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace_cc
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace_metadata
-
-          cargo publish --token "${CRATES_TOKEN}" -p lace
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          PACKAGE_ORDER: "lace_utils lace_consts lace_data lace_stats lace_codebook lace_geweke lace_cc lace_metadata lace"
+        run: |
+          for PACKAGE_NAME in $PACKAGE_ORDER
+          do
+            echo "Processing package $PACKAGE_NAME"
+            if [ "$PACKAGE_NAME" == 'lace' ]
+            then
+              CARGO_FILE="Cargo.toml"
+            else
+              CARGO_FILE="$PACKAGE_NAME/Cargo.toml"
+            fi
+            PACKAGE_VERSION=$(tomlq .package.version $CARGO_FILE)
+            ALREADY_PUBLISHED=$(cargo crate info $PACKAGE_NAME --json --max-versions 100 | jq '[.krate.versions[].num] | any(. == '$PACKAGE_VERSION')')
+            if [ "$ALREADY_PUBLISHED" == 'false' ]
+            then
+              cargo publish --token "${CRATES_TOKEN}" -p $PACKAGE_NAME --dry-run
+            fi
+          done


### PR DESCRIPTION
This is a change to the Cargo Publish step, for a new release process. The big change is that we only force the tag to match the main lace version, not any of the subcrates, and we only publish a crate if (we think) that it hasn't been published already.

One thing that's NOT covered here is enforcing matching version bumps, i.e. enforcing that if you bump a subcrate on a MINOR version, you make sure to bump the main crate by at least a MINOR. That will have to be managed by devs, at least for now.

I specifically didn't change anything for the python project; we don't actually publish the python crate to crates.io, so in practice I don't think it makes sense to let the pylace crate vary from the Python project version.

I've tested this code locally but haven't actually tried to run it in GitHub; I'm working on a way to make that happen, separate from all of this.
