### PR TITLE
Specify all versions of Python to build wheels for explicitly

### DIFF
--- a/.github/scripts/run_code_in_mdfile.py
+++ b/.github/scripts/run_code_in_mdfile.py
@@ -44,7 +44,7 @@ def process_file(file, language, version):
             rust_script_contents = f"""//! ```cargo
         //! [dependencies]
         //! lace = {{ path = ".", version="{version}" }}
-        //! polars = {{ version = "0.31", features=["csv"] }}
+        //! polars = {{ version = "0.32", features=["csv"] }}
         //! rand = "0.8"
         //! rand_xoshiro = "0.6"
         //! ```

--- a/.github/scripts/run_code_in_mdfile.py
+++ b/.github/scripts/run_code_in_mdfile.py
@@ -44,7 +44,7 @@ def process_file(file, language, version):
             rust_script_contents = f"""//! ```cargo
         //! [dependencies]
         //! lace = {{ path = ".", version="{version}" }}
-        //! polars = {{ version = "0.32", features=["csv"] }}
+        //! polars = {{ version = "=0.32.0", features=["csv"] }}
         //! rand = "0.8"
         //! rand_xoshiro = "0.6"
         //! ```

--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -94,13 +94,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path pylace/Cargo.toml
+          args: --release --out dist -i python3.8 -i python3.9 -i python3.10 -i python3.11 --manifest-path pylace/Cargo.toml
           manylinux: auto
     
       - name: Install dev dependencies
@@ -130,13 +134,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
           architecture: ${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path pylace/Cargo.toml
+          args: --release --out dist -i python3.8 -i python3.9 -i python3.10 -i python3.11 --manifest-path pylace/Cargo.toml
     
       - name: Install dev dependencies
         run: |
@@ -165,13 +173,17 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: |
+            3.8
+            3.9
+            3.10
+            3.11
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path pylace/Cargo.toml
-    
+          args: --release --out dist -i python3.8 -i python3.9 -i python3.10 -i python3.11 --manifest-path pylace/Cargo.toml
+
       - name: Install dev dependencies
         if: ${{ matrix.target != 'aarch64' }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [python-0.3.1]
+## [python-0.3.1] - 2023-08-28
 
 ### Fixed
 
 - Automatic conversion from `np.int*` types to Categorical.
+- Updated lace version to 0.3.1
 
-## [python-0.3.0]
+## [rust-0.3.1] - 2023-08-28
+
+### Fixed
+
+- Locked to a specific version of `polars 0.32` to produce reproducible builds on Rust 1.72
+
+## [python-0.3.0] - 2023-07-25
 
 ### Changed
 
 - Updated lace version to 0.3.0
 - Updated polars to version ^0.31
 
-## [python-0.2.0]
+## [rust-0.3.0] - 2023-07-25
+
+## Fixed
+
+- Updated breaking dependencies
+
+## [python-0.2.0] - 2023-07-14
 
 ### Changed
 
@@ -36,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Can delete columns using `Engine.del_column`
 - New plot: `lace.plot.prediction_uncertainty`
 
-## [rust-0.2.0]
+## [rust-0.2.0] - 2023-07-14
 
 ### Changed
 
@@ -104,8 +117,17 @@ Initial release on [PyPi](https://pypi.org/)
 
 Initial release on [crates.io](https://crates.io/)
 
-[unreleased]: https://github.com/promised-ai/lace/compare/python-0.1.0...HEAD
-[rust-0.1.1]: https://github.com/promised-ai/lace/compare/rust-0.1.1...rust-0.1.0
+[unreleased]: https://github.com/promised-ai/lace/compare/python-0.3.1...HEAD
+[python-0.3.1]: https://github.com/promised-ai/lace/compare/python-0.3.0...python-0.3.1
+[rust-0.3.1]: https://github.com/promised-ai/lace/compare/rust-0.3.0...rust-0.3.1
+[python-0.3.0]: https://github.com/promised-ai/lace/compare/python-0.2.0...python-0.3.0
+[rust-0.3.0]: https://github.com/promised-ai/lace/compare/rust-0.2.0...rust-0.3.0
+[python-0.2.0]: https://github.com/promised-ai/lace/compare/python-0.1.2...python-0.2.0
+[rust-0.2.0]: https://github.com/promised-ai/lace/compare/rust-0.1.2...rust-0.2.0
+[python-0.1.2]: https://github.com/promised-ai/lace/compare/python-0.1.1...python-0.1.2
+[python-0.1.1]: https://github.com/promised-ai/lace/compare/python-0.1.0...python-0.1.1
+[rust-0.1.2]: https://github.com/promised-ai/lace/compare/rust-0.1.1...rust-0.1.2
+[rust-0.1.1]: https://github.com/promised-ai/lace/compare/rust-0.1.0...rust-0.1.1
 [python-0.1.0]: https://github.com/promised-ai/lace/releases/tag/python-0.1.0
 [rust-0.1.0]: https://github.com/promised-ai/lace/releases/tag/rust-0.1.0
 

--- a/book/lace_preprocess_mdbook_yaml/Cargo.lock
+++ b/book/lace_preprocess_mdbook_yaml/Cargo.lock
@@ -424,15 +424,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,7 +748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1482,16 +1472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
+checksum = "7298f78a752ab4374b2158cd25346a30885af955b52f16404ecd1f603cedf987"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -2134,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f967c901fa5da4ca7f64e813d1268488ba97e9b3004cefc579ff851c197a1138"
+checksum = "6d16e1c69d8b0904fd5468ec87e58dbd1ff70eade5dcee7d2998a5aeef73e7d5"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2151,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
+checksum = "f6185468ae1f3c4e59ca7ff0c35a1ee131b6b646f26320cad37dd9ed9372b19c"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2182,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d09c3a7337e53b38c37b57999038440fa39c6801b9ba48afaecd8e16f7ac0a"
+checksum = "66a7d4c872ec0775112a0c527a8d4f74e2ef92f024b795fe7a8b00a21910a5dc"
 dependencies = [
  "arrow2",
  "regex",
@@ -2193,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cab0df9f2a35702fa5aec99edfaabf9ae8e9cdd0acf69e143ad2d132f34f9c"
+checksum = "ffbf1693b4f0a87bd576f02c11ebd3d3413199ac919d821c635536144e80affe"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2228,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e58094557cf6446808c7348dcb797885db61815857f6ea02924b35505566e94"
+checksum = "0f1c6c79be2387ffb2f20743d192c11083be0e8bc0adf6d742ce28f1e7ca1142"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2246,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
+checksum = "707075e6317b047864cccc665d4d27c4936ecdfe54798019bb6dc1d0bc237063"
 dependencies = [
  "ahash",
  "bitflags 2.4.0",
@@ -2270,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825575c96302d2daedfc205a0062180033c92c55bcd6aafc4e109d4d8849ed0"
+checksum = "d4e64910ae597343e3bec8c90c5c5db59ca835e28296dda725718bbc0ce91d15"
 dependencies = [
  "argminmax",
  "arrow2",
@@ -2288,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2bc9a12da9ed043fb0cb51dbcb87b365e4845b7ab6399d7a81e838460c6974"
+checksum = "d9072be429b07e9282ec24030bc379fe77237aeda78c87a6f566d5d04a9e52e0"
 dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
@@ -2309,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb67b014f0295e8e9dbb84404a91d666d477b3bc248a2ed51bc442833b16da35"
+checksum = "289b7f2a9139fe13622872860207ef282aea0534578f917e0705a4bab73751aa"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2331,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f54c1956027bf6301948fb4f2837cf6d6b638d8dd1edf3aaeaa19906a986be"
+checksum = "a238c05921b0bd0064aaa2b9155909c9ff7ed92418fffd3f9f84ba4444531a43"
 dependencies = [
  "arrow2",
  "polars-error",
@@ -2342,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfcb15cf8eebd25ea1724109d0153817cd484c6326290585f0736b4e7fcf2f4"
+checksum = "d0ae24b6aaa2b2edbee81f2f74cea0e54d71686f121c03d14115297641c6c096"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2357,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f42d2632f5971c9575041d33cbcfb1f996900c40bbf58bc6eb0a0c5efbecea"
+checksum = "c8b7d1b30aa65e113d7abd3bd5f3c301df2e033c5fb0d2085c12847b2d9484b3"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2376,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c326708a370d71dc6e11a8f4bbc10a8479e1c314dc048ba73543b815cd0bf339"
+checksum = "e38f1f0fee4bf34bfcb37ba556c69644097270c4fc6a722708d3f7a9e8c0b692"
 dependencies = [
  "ahash",
  "hashbrown 0.14.0",

--- a/book/lace_preprocess_mdbook_yaml/Cargo.lock
+++ b/book/lace_preprocess_mdbook_yaml/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44f27e89e3edd8738a07c5e2c881efaa25e69be97a816d2df051685d460670c"
+checksum = "59c468daea140b747d781a1da9f7db5f0a8e6636d4af20cc539e43d05b0604fa"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -270,6 +270,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -395,7 +401,7 @@ checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
  "strsim",
@@ -416,6 +422,15 @@ name = "clap_lex"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -518,11 +533,11 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -742,6 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1003,7 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -1198,7 +1214,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -1299,7 +1315,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1330,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "lace_data"
-version = "0.1.3"
+version = "0.1.2"
 dependencies = [
  "lace_utils",
  "regex",
@@ -1464,6 +1480,16 @@ name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+dependencies = [
+ "cmake",
+ "libc",
+]
 
 [[package]]
 name = "link-cplusplus"
@@ -1609,9 +1635,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -1664,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cda45dade5144c2c929bf2ed6c24bebbba784e9198df049ec87d722b9462bd1"
+checksum = "b2c7b9d7fe61760ce5ea19532ead98541f6b4c495d87247aff9826445cf6872a"
 dependencies = [
  "multiversion-macros",
  "target-features",
@@ -1674,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion-macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bffdccbd4798b61dce08c97ce8c66a68976f95541aaf284a6e90c1d1c306e1"
+checksum = "26a83d8500ed06d68877e9de1dde76c1dbb83885dcdbda4ef44ccbc3fbda2ac8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1724,7 +1750,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1876,37 +1902,12 @@ checksum = "efa535d5117d3661134dbf1719b6f0ffe06f2375843b13935db186cd094105eb"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2117,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e072ca6b1c26e686b18d86b607a17b1f8baa5fb0a713a1fefe033f0aa527bfd"
+checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -2133,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f7b885c589dd7184c881be3dfb149feb1f405083fdd2fd9194e8f96104b76"
+checksum = "f967c901fa5da4ca7f64e813d1268488ba97e9b3004cefc579ff851c197a1138"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2145,17 +2146,18 @@ dependencies = [
  "num-traits",
  "polars-error",
  "thiserror",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f98d6b1ef5362f76063b4984634d371de72f4834f50892944d48fd7b7d5ae45"
+checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
 dependencies = [
  "ahash",
  "arrow2",
- "bitflags",
+ "bitflags 2.4.0",
  "chrono",
  "comfy-table",
  "either",
@@ -2174,15 +2176,15 @@ dependencies = [
  "regex",
  "smartstring",
  "thiserror",
- "wasm-timer",
+ "version_check",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "polars-error"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1557cd24b1865194bac6979765cfec5e97ecd8af5dcb7858a17b31d1e7fbf70"
+checksum = "40d09c3a7337e53b38c37b57999038440fa39c6801b9ba48afaecd8e16f7ac0a"
 dependencies = [
  "arrow2",
  "regex",
@@ -2191,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44b1c6d7b2c04e459effb93bac050f90762687cb752c534967476c452478a65"
+checksum = "92cab0df9f2a35702fa5aec99edfaabf9ae8e9cdd0acf69e143ad2d132f34f9c"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2226,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eef6b83136b3884ce356ed74b58eeedc81d81b981e901fbd15f16c96a5ff315"
+checksum = "9e58094557cf6446808c7348dcb797885db61815857f6ea02924b35505566e94"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2244,12 +2246,12 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494f1e75a035978339b06bdcc4d60523ec347243ac65f11794a7eeaba0507d4e"
+checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.4.0",
  "glob",
  "once_cell",
  "polars-arrow",
@@ -2263,13 +2265,14 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-ops"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06dd95bc84a7bf17886670420097c5fb8b88906ebb16653153ce5f0cf71ffd6e"
+checksum = "e825575c96302d2daedfc205a0062180033c92c55bcd6aafc4e109d4d8849ed0"
 dependencies = [
  "argminmax",
  "arrow2",
@@ -2280,13 +2283,14 @@ dependencies = [
  "polars-core",
  "polars-utils",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-pipe"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff34c8f09c064ab26bc9283c13b6a1571083c30c4c3812301cd84cdd3982a2e0"
+checksum = "1f2bc9a12da9ed043fb0cb51dbcb87b365e4845b7ab6399d7a81e838460c6974"
 dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
@@ -2300,13 +2304,14 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-plan"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f0837dac2b7064e04a2a37a2bff20f75a455d23b29f2dd82f0345de62d3bfb"
+checksum = "fb67b014f0295e8e9dbb84404a91d666d477b3bc248a2ed51bc442833b16da35"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2321,13 +2326,14 @@ dependencies = [
  "regex",
  "smartstring",
  "strum_macros 0.25.1",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46235f6f67005fff3fd8095b994e86f846b5affd6fc6f36f41099a4dbc27d714"
+checksum = "27f54c1956027bf6301948fb4f2837cf6d6b638d8dd1edf3aaeaa19906a986be"
 dependencies = [
  "arrow2",
  "polars-error",
@@ -2336,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f716671c8e8ed1db6ebdbfcc7ca0c98a599e92c340747c24072b86e8839bed"
+checksum = "dbfcb15cf8eebd25ea1724109d0153817cd484c6326290585f0736b4e7fcf2f4"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2351,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02488938edfbff6efed56a4f90ebd6574ea16a7d32b6dc678134624031f7f3e9"
+checksum = "53f42d2632f5971c9575041d33cbcfb1f996900c40bbf58bc6eb0a0c5efbecea"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2370,17 +2376,19 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f04f6c127b8d20292b4d49b5fb0e47c652875b316274f74f52e77d50f6a459"
+checksum = "c326708a370d71dc6e11a8f4bbc10a8479e1c314dc048ba73543b815cd0bf339"
 dependencies = [
  "ahash",
  "hashbrown 0.14.0",
  "num-traits",
  "once_cell",
+ "polars-error",
  "rayon",
  "smartstring",
  "sysinfo",
+ "version_check",
 ]
 
 [[package]]
@@ -2410,7 +2418,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -2515,7 +2523,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2524,7 +2532,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2571,7 +2579,7 @@ version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2873,9 +2881,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
+checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
 dependencies = [
  "log",
 ]
@@ -2915,7 +2923,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "phf_shared",
  "precomputed-hash",
  "serde",
@@ -3409,18 +3417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,31 +3444,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "wide"

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -494,15 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,7 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1516,16 +1506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
+checksum = "7298f78a752ab4374b2158cd25346a30885af955b52f16404ecd1f603cedf987"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -2075,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f967c901fa5da4ca7f64e813d1268488ba97e9b3004cefc579ff851c197a1138"
+checksum = "6d16e1c69d8b0904fd5468ec87e58dbd1ff70eade5dcee7d2998a5aeef73e7d5"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2092,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
+checksum = "f6185468ae1f3c4e59ca7ff0c35a1ee131b6b646f26320cad37dd9ed9372b19c"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2123,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d09c3a7337e53b38c37b57999038440fa39c6801b9ba48afaecd8e16f7ac0a"
+checksum = "66a7d4c872ec0775112a0c527a8d4f74e2ef92f024b795fe7a8b00a21910a5dc"
 dependencies = [
  "arrow2",
  "regex",
@@ -2134,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cab0df9f2a35702fa5aec99edfaabf9ae8e9cdd0acf69e143ad2d132f34f9c"
+checksum = "ffbf1693b4f0a87bd576f02c11ebd3d3413199ac919d821c635536144e80affe"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2169,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e58094557cf6446808c7348dcb797885db61815857f6ea02924b35505566e94"
+checksum = "0f1c6c79be2387ffb2f20743d192c11083be0e8bc0adf6d742ce28f1e7ca1142"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2187,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
+checksum = "707075e6317b047864cccc665d4d27c4936ecdfe54798019bb6dc1d0bc237063"
 dependencies = [
  "ahash",
  "bitflags 2.3.3",
@@ -2211,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825575c96302d2daedfc205a0062180033c92c55bcd6aafc4e109d4d8849ed0"
+checksum = "d4e64910ae597343e3bec8c90c5c5db59ca835e28296dda725718bbc0ce91d15"
 dependencies = [
  "argminmax",
  "arrow2",
@@ -2229,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2bc9a12da9ed043fb0cb51dbcb87b365e4845b7ab6399d7a81e838460c6974"
+checksum = "d9072be429b07e9282ec24030bc379fe77237aeda78c87a6f566d5d04a9e52e0"
 dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
@@ -2250,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb67b014f0295e8e9dbb84404a91d666d477b3bc248a2ed51bc442833b16da35"
+checksum = "289b7f2a9139fe13622872860207ef282aea0534578f917e0705a4bab73751aa"
 dependencies = [
  "ahash",
  "arrow2",
@@ -2272,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f54c1956027bf6301948fb4f2837cf6d6b638d8dd1edf3aaeaa19906a986be"
+checksum = "a238c05921b0bd0064aaa2b9155909c9ff7ed92418fffd3f9f84ba4444531a43"
 dependencies = [
  "arrow2",
  "polars-error",
@@ -2283,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfcb15cf8eebd25ea1724109d0153817cd484c6326290585f0736b4e7fcf2f4"
+checksum = "d0ae24b6aaa2b2edbee81f2f74cea0e54d71686f121c03d14115297641c6c096"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2298,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f42d2632f5971c9575041d33cbcfb1f996900c40bbf58bc6eb0a0c5efbecea"
+checksum = "c8b7d1b30aa65e113d7abd3bd5f3c301df2e033c5fb0d2085c12847b2d9484b3"
 dependencies = [
  "arrow2",
  "atoi",
@@ -2317,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.32.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c326708a370d71dc6e11a8f4bbc10a8479e1c314dc048ba73543b815cd0bf339"
+checksum = "e38f1f0fee4bf34bfcb37ba556c69644097270c4fc6a722708d3f7a9e8c0b692"
 dependencies = [
  "ahash",
  "hashbrown 0.14.0",

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1279,7 +1279,7 @@ dependencies = [
  "num",
  "once_cell",
  "plotly",
- "polars 0.31.1",
+ "polars",
  "rand",
  "rand_distr",
  "rand_xoshiro",
@@ -1330,7 +1330,7 @@ dependencies = [
  "lace_stats",
  "lace_utils",
  "maplit",
- "polars 0.32.1",
+ "polars",
  "rand",
  "rayon",
  "serde",
@@ -1606,15 +1606,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memmap2"
@@ -1896,37 +1887,12 @@ checksum = "efa535d5117d3661134dbf1719b6f0ffe06f2375843b13935db186cd094105eb"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2093,50 +2059,18 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e072ca6b1c26e686b18d86b607a17b1f8baa5fb0a713a1fefe033f0aa527bfd"
-dependencies = [
- "getrandom",
- "polars-core 0.31.1",
- "polars-io 0.31.1",
- "polars-lazy 0.31.1",
- "polars-ops 0.31.1",
- "polars-sql 0.31.1",
- "polars-time 0.31.1",
- "version_check",
-]
-
-[[package]]
-name = "polars"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
 dependencies = [
  "getrandom",
- "polars-core 0.32.1",
- "polars-io 0.32.1",
- "polars-lazy 0.32.1",
- "polars-ops 0.32.1",
- "polars-sql 0.32.1",
- "polars-time 0.32.1",
+ "polars-core",
+ "polars-io",
+ "polars-lazy",
+ "polars-ops",
+ "polars-sql",
+ "polars-time",
  "version_check",
-]
-
-[[package]]
-name = "polars-arrow"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f7b885c589dd7184c881be3dfb149feb1f405083fdd2fd9194e8f96104b76"
-dependencies = [
- "arrow2",
- "atoi",
- "ethnum",
- "hashbrown 0.14.0",
- "multiversion",
- "num-traits",
- "polars-error 0.31.1",
- "thiserror",
 ]
 
 [[package]]
@@ -2151,40 +2085,9 @@ dependencies = [
  "hashbrown 0.14.0",
  "multiversion",
  "num-traits",
- "polars-error 0.32.1",
+ "polars-error",
  "thiserror",
  "version_check",
-]
-
-[[package]]
-name = "polars-core"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f98d6b1ef5362f76063b4984634d371de72f4834f50892944d48fd7b7d5ae45"
-dependencies = [
- "ahash",
- "arrow2",
- "bitflags 1.3.2",
- "chrono",
- "comfy-table",
- "either",
- "hashbrown 0.14.0",
- "indexmap 2.0.0",
- "itoap",
- "num-traits",
- "once_cell",
- "polars-arrow 0.31.1",
- "polars-error 0.31.1",
- "polars-row 0.31.1",
- "polars-utils 0.31.1",
- "rand",
- "rand_distr",
- "rayon",
- "regex",
- "smartstring",
- "thiserror",
- "wasm-timer",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -2204,10 +2107,10 @@ dependencies = [
  "itoap",
  "num-traits",
  "once_cell",
- "polars-arrow 0.32.1",
- "polars-error 0.32.1",
- "polars-row 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-error",
+ "polars-row",
+ "polars-utils",
  "rand",
  "rand_distr",
  "rayon",
@@ -2220,17 +2123,6 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1557cd24b1865194bac6979765cfec5e97ecd8af5dcb7858a17b31d1e7fbf70"
-dependencies = [
- "arrow2",
- "regex",
- "thiserror",
-]
-
-[[package]]
-name = "polars-error"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40d09c3a7337e53b38c37b57999038440fa39c6801b9ba48afaecd8e16f7ac0a"
@@ -2238,41 +2130,6 @@ dependencies = [
  "arrow2",
  "regex",
  "thiserror",
-]
-
-[[package]]
-name = "polars-io"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44b1c6d7b2c04e459effb93bac050f90762687cb752c534967476c452478a65"
-dependencies = [
- "ahash",
- "arrow2",
- "async-trait",
- "bytes",
- "chrono",
- "fast-float",
- "flate2",
- "futures",
- "home",
- "lexical",
- "lexical-core",
- "memchr",
- "memmap2 0.5.10",
- "num-traits",
- "once_cell",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-error 0.31.1",
- "polars-json 0.31.1",
- "polars-time 0.31.1",
- "polars-utils 0.31.1",
- "rayon",
- "regex",
- "serde_json",
- "simd-json",
- "simdutf8",
- "tokio",
 ]
 
 [[package]]
@@ -2293,39 +2150,21 @@ dependencies = [
  "lexical",
  "lexical-core",
  "memchr",
- "memmap2 0.7.1",
+ "memmap2",
  "num-traits",
  "once_cell",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-error 0.32.1",
- "polars-json 0.32.1",
- "polars-time 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-error",
+ "polars-json",
+ "polars-time",
+ "polars-utils",
  "rayon",
  "regex",
  "serde_json",
  "simd-json",
  "simdutf8",
  "tokio",
-]
-
-[[package]]
-name = "polars-json"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eef6b83136b3884ce356ed74b58eeedc81d81b981e901fbd15f16c96a5ff315"
-dependencies = [
- "ahash",
- "arrow2",
- "fallible-streaming-iterator",
- "hashbrown 0.14.0",
- "indexmap 2.0.0",
- "num-traits",
- "polars-arrow 0.31.1",
- "polars-error 0.31.1",
- "polars-utils 0.31.1",
- "simd-json",
 ]
 
 [[package]]
@@ -2340,33 +2179,10 @@ dependencies = [
  "hashbrown 0.14.0",
  "indexmap 2.0.0",
  "num-traits",
- "polars-arrow 0.32.1",
- "polars-error 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-error",
+ "polars-utils",
  "simd-json",
-]
-
-[[package]]
-name = "polars-lazy"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494f1e75a035978339b06bdcc4d60523ec347243ac65f11794a7eeaba0507d4e"
-dependencies = [
- "ahash",
- "bitflags 1.3.2",
- "glob",
- "once_cell",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-io 0.31.1",
- "polars-json 0.31.1",
- "polars-ops 0.31.1",
- "polars-pipe 0.31.1",
- "polars-plan 0.31.1",
- "polars-time 0.31.1",
- "polars-utils 0.31.1",
- "rayon",
- "smartstring",
 ]
 
 [[package]]
@@ -2379,35 +2195,18 @@ dependencies = [
  "bitflags 2.3.3",
  "glob",
  "once_cell",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-io 0.32.1",
- "polars-json 0.32.1",
- "polars-ops 0.32.1",
- "polars-pipe 0.32.1",
- "polars-plan 0.32.1",
- "polars-time 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-io",
+ "polars-json",
+ "polars-ops",
+ "polars-pipe",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
  "rayon",
  "smartstring",
  "version_check",
-]
-
-[[package]]
-name = "polars-ops"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06dd95bc84a7bf17886670420097c5fb8b88906ebb16653153ce5f0cf71ffd6e"
-dependencies = [
- "argminmax",
- "arrow2",
- "either",
- "indexmap 2.0.0",
- "memchr",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-utils 0.31.1",
- "smartstring",
 ]
 
 [[package]]
@@ -2421,31 +2220,11 @@ dependencies = [
  "either",
  "indexmap 2.0.0",
  "memchr",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-utils",
  "smartstring",
  "version_check",
-]
-
-[[package]]
-name = "polars-pipe"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff34c8f09c064ab26bc9283c13b6a1571083c30c4c3812301cd84cdd3982a2e0"
-dependencies = [
- "enum_dispatch",
- "hashbrown 0.14.0",
- "num-traits",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-io 0.31.1",
- "polars-ops 0.31.1",
- "polars-plan 0.31.1",
- "polars-row 0.31.1",
- "polars-utils 0.31.1",
- "rayon",
- "smartstring",
 ]
 
 [[package]]
@@ -2457,37 +2236,16 @@ dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
  "num-traits",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-io 0.32.1",
- "polars-ops 0.32.1",
- "polars-plan 0.32.1",
- "polars-row 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-row",
+ "polars-utils",
  "rayon",
  "smartstring",
  "version_check",
-]
-
-[[package]]
-name = "polars-plan"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f0837dac2b7064e04a2a37a2bff20f75a455d23b29f2dd82f0345de62d3bfb"
-dependencies = [
- "ahash",
- "arrow2",
- "once_cell",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-io 0.31.1",
- "polars-ops 0.31.1",
- "polars-time 0.31.1",
- "polars-utils 0.31.1",
- "rayon",
- "regex",
- "smartstring",
- "strum_macros 0.25.1",
 ]
 
 [[package]]
@@ -2499,12 +2257,12 @@ dependencies = [
  "ahash",
  "arrow2",
  "once_cell",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-io 0.32.1",
- "polars-ops 0.32.1",
- "polars-time 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-io",
+ "polars-ops",
+ "polars-time",
+ "polars-utils",
  "rayon",
  "regex",
  "smartstring",
@@ -2514,39 +2272,13 @@ dependencies = [
 
 [[package]]
 name = "polars-row"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46235f6f67005fff3fd8095b994e86f846b5affd6fc6f36f41099a4dbc27d714"
-dependencies = [
- "arrow2",
- "polars-error 0.31.1",
- "polars-utils 0.31.1",
-]
-
-[[package]]
-name = "polars-row"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27f54c1956027bf6301948fb4f2837cf6d6b638d8dd1edf3aaeaa19906a986be"
 dependencies = [
  "arrow2",
- "polars-error 0.32.1",
- "polars-utils 0.32.1",
-]
-
-[[package]]
-name = "polars-sql"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f716671c8e8ed1db6ebdbfcc7ca0c98a599e92c340747c24072b86e8839bed"
-dependencies = [
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-lazy 0.31.1",
- "polars-plan 0.31.1",
- "serde",
- "serde_json",
- "sqlparser 0.34.0",
+ "polars-error",
+ "polars-utils",
 ]
 
 [[package]]
@@ -2555,32 +2287,13 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfcb15cf8eebd25ea1724109d0153817cd484c6326290585f0736b4e7fcf2f4"
 dependencies = [
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-lazy 0.32.1",
- "polars-plan 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-lazy",
+ "polars-plan",
  "serde",
  "serde_json",
- "sqlparser 0.36.1",
-]
-
-[[package]]
-name = "polars-time"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02488938edfbff6efed56a4f90ebd6574ea16a7d32b6dc678134624031f7f3e9"
-dependencies = [
- "arrow2",
- "atoi",
- "chrono",
- "now",
- "once_cell",
- "polars-arrow 0.31.1",
- "polars-core 0.31.1",
- "polars-ops 0.31.1",
- "polars-utils 0.31.1",
- "regex",
- "smartstring",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2594,27 +2307,12 @@ dependencies = [
  "chrono",
  "now",
  "once_cell",
- "polars-arrow 0.32.1",
- "polars-core 0.32.1",
- "polars-ops 0.32.1",
- "polars-utils 0.32.1",
+ "polars-arrow",
+ "polars-core",
+ "polars-ops",
+ "polars-utils",
  "regex",
  "smartstring",
-]
-
-[[package]]
-name = "polars-utils"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f04f6c127b8d20292b4d49b5fb0e47c652875b316274f74f52e77d50f6a459"
-dependencies = [
- "ahash",
- "hashbrown 0.14.0",
- "num-traits",
- "once_cell",
- "rayon",
- "smartstring",
- "sysinfo",
 ]
 
 [[package]]
@@ -2627,7 +2325,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "num-traits",
  "once_cell",
- "polars-error 0.32.1",
+ "polars-error",
  "rayon",
  "smartstring",
  "sysinfo",
@@ -3131,15 +2829,6 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "sqlparser"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
@@ -3491,18 +3180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,21 +3207,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "web-sys"

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44f27e89e3edd8738a07c5e2c881efaa25e69be97a816d2df051685d460670c"
+checksum = "59c468daea140b747d781a1da9f7db5f0a8e6636d4af20cc539e43d05b0604fa"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -492,6 +492,15 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -863,6 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1269,7 +1279,7 @@ dependencies = [
  "num",
  "once_cell",
  "plotly",
- "polars",
+ "polars 0.31.1",
  "rand",
  "rand_distr",
  "rand_xoshiro",
@@ -1320,7 +1330,7 @@ dependencies = [
  "lace_stats",
  "lace_utils",
  "maplit",
- "polars",
+ "polars 0.32.1",
  "rand",
  "rayon",
  "serde",
@@ -1506,6 +1516,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cda45dade5144c2c929bf2ed6c24bebbba784e9198df049ec87d722b9462bd1"
+checksum = "b2c7b9d7fe61760ce5ea19532ead98541f6b4c495d87247aff9826445cf6872a"
 dependencies = [
  "multiversion-macros",
  "target-features",
@@ -1660,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion-macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bffdccbd4798b61dce08c97ce8c66a68976f95541aaf284a6e90c1d1c306e1"
+checksum = "26a83d8500ed06d68877e9de1dde76c1dbb83885dcdbda4ef44ccbc3fbda2ac8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2069,12 +2098,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e072ca6b1c26e686b18d86b607a17b1f8baa5fb0a713a1fefe033f0aa527bfd"
 dependencies = [
  "getrandom",
- "polars-core",
- "polars-io",
- "polars-lazy",
- "polars-ops",
- "polars-sql",
- "polars-time",
+ "polars-core 0.31.1",
+ "polars-io 0.31.1",
+ "polars-lazy 0.31.1",
+ "polars-ops 0.31.1",
+ "polars-sql 0.31.1",
+ "polars-time 0.31.1",
+ "version_check",
+]
+
+[[package]]
+name = "polars"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1362d4a136c0ebacb40d88a37ba361738b222fd8a2ee9340a3d8642f698c52b"
+dependencies = [
+ "getrandom",
+ "polars-core 0.32.1",
+ "polars-io 0.32.1",
+ "polars-lazy 0.32.1",
+ "polars-ops 0.32.1",
+ "polars-sql 0.32.1",
+ "polars-time 0.32.1",
  "version_check",
 ]
 
@@ -2090,8 +2135,25 @@ dependencies = [
  "hashbrown 0.14.0",
  "multiversion",
  "num-traits",
- "polars-error",
+ "polars-error 0.31.1",
  "thiserror",
+]
+
+[[package]]
+name = "polars-arrow"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f967c901fa5da4ca7f64e813d1268488ba97e9b3004cefc579ff851c197a1138"
+dependencies = [
+ "arrow2",
+ "atoi",
+ "ethnum",
+ "hashbrown 0.14.0",
+ "multiversion",
+ "num-traits",
+ "polars-error 0.32.1",
+ "thiserror",
+ "version_check",
 ]
 
 [[package]]
@@ -2111,10 +2173,10 @@ dependencies = [
  "itoap",
  "num-traits",
  "once_cell",
- "polars-arrow",
- "polars-error",
- "polars-row",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-error 0.31.1",
+ "polars-row 0.31.1",
+ "polars-utils 0.31.1",
  "rand",
  "rand_distr",
  "rayon",
@@ -2126,10 +2188,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-core"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24f92fc5b167f668ff85ab9607dfa72e2c09664cacef59297ee8601dee60126"
+dependencies = [
+ "ahash",
+ "arrow2",
+ "bitflags 2.3.3",
+ "chrono",
+ "comfy-table",
+ "either",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "itoap",
+ "num-traits",
+ "once_cell",
+ "polars-arrow 0.32.1",
+ "polars-error 0.32.1",
+ "polars-row 0.32.1",
+ "polars-utils 0.32.1",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "regex",
+ "smartstring",
+ "thiserror",
+ "version_check",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "polars-error"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1557cd24b1865194bac6979765cfec5e97ecd8af5dcb7858a17b31d1e7fbf70"
+dependencies = [
+ "arrow2",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "polars-error"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d09c3a7337e53b38c37b57999038440fa39c6801b9ba48afaecd8e16f7ac0a"
 dependencies = [
  "arrow2",
  "regex",
@@ -2154,15 +2258,50 @@ dependencies = [
  "lexical",
  "lexical-core",
  "memchr",
- "memmap2",
+ "memmap2 0.5.10",
  "num-traits",
  "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-error",
- "polars-json",
- "polars-time",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-error 0.31.1",
+ "polars-json 0.31.1",
+ "polars-time 0.31.1",
+ "polars-utils 0.31.1",
+ "rayon",
+ "regex",
+ "serde_json",
+ "simd-json",
+ "simdutf8",
+ "tokio",
+]
+
+[[package]]
+name = "polars-io"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92cab0df9f2a35702fa5aec99edfaabf9ae8e9cdd0acf69e143ad2d132f34f9c"
+dependencies = [
+ "ahash",
+ "arrow2",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "fast-float",
+ "flate2",
+ "futures",
+ "home",
+ "lexical",
+ "lexical-core",
+ "memchr",
+ "memmap2 0.7.1",
+ "num-traits",
+ "once_cell",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-error 0.32.1",
+ "polars-json 0.32.1",
+ "polars-time 0.32.1",
+ "polars-utils 0.32.1",
  "rayon",
  "regex",
  "serde_json",
@@ -2183,9 +2322,27 @@ dependencies = [
  "hashbrown 0.14.0",
  "indexmap 2.0.0",
  "num-traits",
- "polars-arrow",
- "polars-error",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-error 0.31.1",
+ "polars-utils 0.31.1",
+ "simd-json",
+]
+
+[[package]]
+name = "polars-json"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e58094557cf6446808c7348dcb797885db61815857f6ea02924b35505566e94"
+dependencies = [
+ "ahash",
+ "arrow2",
+ "fallible-streaming-iterator",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "num-traits",
+ "polars-arrow 0.32.1",
+ "polars-error 0.32.1",
+ "polars-utils 0.32.1",
  "simd-json",
 ]
 
@@ -2199,17 +2356,41 @@ dependencies = [
  "bitflags 1.3.2",
  "glob",
  "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-json",
- "polars-ops",
- "polars-pipe",
- "polars-plan",
- "polars-time",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-io 0.31.1",
+ "polars-json 0.31.1",
+ "polars-ops 0.31.1",
+ "polars-pipe 0.31.1",
+ "polars-plan 0.31.1",
+ "polars-time 0.31.1",
+ "polars-utils 0.31.1",
  "rayon",
  "smartstring",
+]
+
+[[package]]
+name = "polars-lazy"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c33762ec2a55e01c9f8776b34db86257c70a0a3b3929bd4eb91a52aacf61456"
+dependencies = [
+ "ahash",
+ "bitflags 2.3.3",
+ "glob",
+ "once_cell",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-io 0.32.1",
+ "polars-json 0.32.1",
+ "polars-ops 0.32.1",
+ "polars-pipe 0.32.1",
+ "polars-plan 0.32.1",
+ "polars-time 0.32.1",
+ "polars-utils 0.32.1",
+ "rayon",
+ "smartstring",
+ "version_check",
 ]
 
 [[package]]
@@ -2223,10 +2404,28 @@ dependencies = [
  "either",
  "indexmap 2.0.0",
  "memchr",
- "polars-arrow",
- "polars-core",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-utils 0.31.1",
  "smartstring",
+]
+
+[[package]]
+name = "polars-ops"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825575c96302d2daedfc205a0062180033c92c55bcd6aafc4e109d4d8849ed0"
+dependencies = [
+ "argminmax",
+ "arrow2",
+ "either",
+ "indexmap 2.0.0",
+ "memchr",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-utils 0.32.1",
+ "smartstring",
+ "version_check",
 ]
 
 [[package]]
@@ -2238,15 +2437,36 @@ dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
  "num-traits",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-row",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-io 0.31.1",
+ "polars-ops 0.31.1",
+ "polars-plan 0.31.1",
+ "polars-row 0.31.1",
+ "polars-utils 0.31.1",
  "rayon",
  "smartstring",
+]
+
+[[package]]
+name = "polars-pipe"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2bc9a12da9ed043fb0cb51dbcb87b365e4845b7ab6399d7a81e838460c6974"
+dependencies = [
+ "enum_dispatch",
+ "hashbrown 0.14.0",
+ "num-traits",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-io 0.32.1",
+ "polars-ops 0.32.1",
+ "polars-plan 0.32.1",
+ "polars-row 0.32.1",
+ "polars-utils 0.32.1",
+ "rayon",
+ "smartstring",
+ "version_check",
 ]
 
 [[package]]
@@ -2258,16 +2478,38 @@ dependencies = [
  "ahash",
  "arrow2",
  "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-time",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-io 0.31.1",
+ "polars-ops 0.31.1",
+ "polars-time 0.31.1",
+ "polars-utils 0.31.1",
  "rayon",
  "regex",
  "smartstring",
  "strum_macros 0.25.1",
+]
+
+[[package]]
+name = "polars-plan"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb67b014f0295e8e9dbb84404a91d666d477b3bc248a2ed51bc442833b16da35"
+dependencies = [
+ "ahash",
+ "arrow2",
+ "once_cell",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-io 0.32.1",
+ "polars-ops 0.32.1",
+ "polars-time 0.32.1",
+ "polars-utils 0.32.1",
+ "rayon",
+ "regex",
+ "smartstring",
+ "strum_macros 0.25.1",
+ "version_check",
 ]
 
 [[package]]
@@ -2277,8 +2519,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46235f6f67005fff3fd8095b994e86f846b5affd6fc6f36f41099a4dbc27d714"
 dependencies = [
  "arrow2",
- "polars-error",
- "polars-utils",
+ "polars-error 0.31.1",
+ "polars-utils 0.31.1",
+]
+
+[[package]]
+name = "polars-row"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f54c1956027bf6301948fb4f2837cf6d6b638d8dd1edf3aaeaa19906a986be"
+dependencies = [
+ "arrow2",
+ "polars-error 0.32.1",
+ "polars-utils 0.32.1",
 ]
 
 [[package]]
@@ -2287,13 +2540,28 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7f716671c8e8ed1db6ebdbfcc7ca0c98a599e92c340747c24072b86e8839bed"
 dependencies = [
- "polars-arrow",
- "polars-core",
- "polars-lazy",
- "polars-plan",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-lazy 0.31.1",
+ "polars-plan 0.31.1",
  "serde",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.34.0",
+]
+
+[[package]]
+name = "polars-sql"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbfcb15cf8eebd25ea1724109d0153817cd484c6326290585f0736b4e7fcf2f4"
+dependencies = [
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-lazy 0.32.1",
+ "polars-plan 0.32.1",
+ "serde",
+ "serde_json",
+ "sqlparser 0.36.1",
 ]
 
 [[package]]
@@ -2307,10 +2575,29 @@ dependencies = [
  "chrono",
  "now",
  "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-ops",
- "polars-utils",
+ "polars-arrow 0.31.1",
+ "polars-core 0.31.1",
+ "polars-ops 0.31.1",
+ "polars-utils 0.31.1",
+ "regex",
+ "smartstring",
+]
+
+[[package]]
+name = "polars-time"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f42d2632f5971c9575041d33cbcfb1f996900c40bbf58bc6eb0a0c5efbecea"
+dependencies = [
+ "arrow2",
+ "atoi",
+ "chrono",
+ "now",
+ "once_cell",
+ "polars-arrow 0.32.1",
+ "polars-core 0.32.1",
+ "polars-ops 0.32.1",
+ "polars-utils 0.32.1",
  "regex",
  "smartstring",
 ]
@@ -2328,6 +2615,23 @@ dependencies = [
  "rayon",
  "smartstring",
  "sysinfo",
+]
+
+[[package]]
+name = "polars-utils"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c326708a370d71dc6e11a8f4bbc10a8479e1c314dc048ba73543b815cd0bf339"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.0",
+ "num-traits",
+ "once_cell",
+ "polars-error 0.32.1",
+ "rayon",
+ "smartstring",
+ "sysinfo",
+ "version_check",
 ]
 
 [[package]]
@@ -2830,6 +3134,15 @@ name = "sqlparser"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
 dependencies = [
  "log",
 ]

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "approx",
  "bincode",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "approx",
  "criterion",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "flate2",
  "indoc",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "dirs",

--- a/lace/Cargo.toml
+++ b/lace/Cargo.toml
@@ -66,7 +66,7 @@ thiserror = "1.0.19"
 indicatif = "0.17.0"
 ctrlc = "3.2.1"
 flate2 = "1.0.23"
-polars = { version = "0.32.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
+polars = { version = "=0.32.0", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/lace/Cargo.toml
+++ b/lace/Cargo.toml
@@ -66,7 +66,7 @@ thiserror = "1.0.19"
 indicatif = "0.17.0"
 ctrlc = "3.2.1"
 flate2 = "1.0.23"
-polars = { version = "0.31.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
+polars = { version = "0.32.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/lace/Cargo.toml
+++ b/lace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Promised AI"]
 build = "build.rs"
 edition = "2021"
@@ -38,7 +38,7 @@ path = "bin/main.rs"
 lace_cc = { path = "lace_cc", version = "0.1.4" }
 lace_utils = { path = "lace_utils", version = "0.1.2" }
 lace_stats = { path = "lace_stats", version = "0.1.3" }
-lace_codebook = { path = "lace_codebook", version = "0.1.4" }
+lace_codebook = { path = "lace_codebook", version = "0.1.5" }
 lace_geweke = { path = "lace_geweke", version = "0.1.2" }
 lace_consts = { path = "lace_consts", version = "0.1.4" }
 lace_data = { path = "lace_data", version = "0.1.2" }

--- a/lace/lace_cc/Cargo.toml
+++ b/lace/lace_cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_cc"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Promised AI"]
 edition = "2021"
 exclude = ["tests/*", "resources/test/*", "target/*"]
@@ -15,7 +15,7 @@ lace_stats = { path = "../lace_stats", version = "0.1.2" }
 lace_geweke = { path = "../lace_geweke", version = "0.1.2" }
 lace_consts = { path = "../lace_consts", version = "0.1.4" }
 lace_data = { path = "../lace_data", version = "0.1.2" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.4" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.5" }
 rand = {version="0.8", features=["serde1"]}
 rayon = "1.5"
 serde = { version = "1", features = ["derive"] }

--- a/lace/lace_codebook/Cargo.toml
+++ b/lace/lace_codebook/Cargo.toml
@@ -20,7 +20,7 @@ rand = {version="0.8.5", features=["serde1"]}
 thiserror = "1.0.11"
 rayon = "1.5"
 flate2 = "1.0.23"
-polars = { version = "0.31.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
+polars = { version = "0.32.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/lace/lace_codebook/Cargo.toml
+++ b/lace/lace_codebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_codebook"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Promised.ai"]
 edition = "2021"
 license = "SSPL-1.0"

--- a/lace/lace_codebook/Cargo.toml
+++ b/lace/lace_codebook/Cargo.toml
@@ -20,7 +20,7 @@ rand = {version="0.8.5", features=["serde1"]}
 thiserror = "1.0.11"
 rayon = "1.5"
 flate2 = "1.0.23"
-polars = { version = "0.32.1", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
+polars = { version = "=0.32.0", features = ["parquet", "json", "ipc", "dtype-full", "decompress"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/lace/lace_metadata/Cargo.toml
+++ b/lace/lace_metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lace_metadata"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Promised AI"]
 edition = "2021"
 license = "SSPL-1.0"
@@ -11,8 +11,8 @@ description = "Archive of the metadata (savefile) formats for Lace. In charge of
 [dependencies]
 lace_stats = { path = "../lace_stats", version = "0.1.4" }
 lace_data = { path = "../lace_data", version = "0.1.2" }
-lace_codebook = { path = "../lace_codebook", version = "0.1.4" }
-lace_cc = { path = "../lace_cc", version = "0.1.4" }
+lace_codebook = { path = "../lace_codebook", version = "0.1.5" }
+lace_cc = { path = "../lace_cc", version = "0.1.5" }
 dirs = "5"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.4"

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44f27e89e3edd8738a07c5e2c881efaa25e69be97a816d2df051685d460670c"
+checksum = "59c468daea140b747d781a1da9f7db5f0a8e6636d4af20cc539e43d05b0604fa"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -500,7 +500,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "lace_data"
-version = "0.1.3"
+version = "0.1.2"
 dependencies = [
  "lace_utils",
  "regex",
@@ -1281,9 +1281,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
 dependencies = [
  "libc",
 ]
@@ -1320,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cda45dade5144c2c929bf2ed6c24bebbba784e9198df049ec87d722b9462bd1"
+checksum = "b2c7b9d7fe61760ce5ea19532ead98541f6b4c495d87247aff9826445cf6872a"
 dependencies = [
  "multiversion-macros",
  "target-features",
@@ -1330,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion-macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bffdccbd4798b61dce08c97ce8c66a68976f95541aaf284a6e90c1d1c306e1"
+checksum = "26a83d8500ed06d68877e9de1dde76c1dbb83885dcdbda4ef44ccbc3fbda2ac8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1521,37 +1521,12 @@ checksum = "efa535d5117d3661134dbf1719b6f0ffe06f2375843b13935db186cd094105eb"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.8",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1654,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e072ca6b1c26e686b18d86b607a17b1f8baa5fb0a713a1fefe033f0aa527bfd"
+checksum = "7298f78a752ab4374b2158cd25346a30885af955b52f16404ecd1f603cedf987"
 dependencies = [
  "getrandom",
  "polars-core",
@@ -1670,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f7b885c589dd7184c881be3dfb149feb1f405083fdd2fd9194e8f96104b76"
+checksum = "6d16e1c69d8b0904fd5468ec87e58dbd1ff70eade5dcee7d2998a5aeef73e7d5"
 dependencies = [
  "arrow2",
  "atoi",
@@ -1682,17 +1657,18 @@ dependencies = [
  "num-traits",
  "polars-error",
  "thiserror",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f98d6b1ef5362f76063b4984634d371de72f4834f50892944d48fd7b7d5ae45"
+checksum = "f6185468ae1f3c4e59ca7ff0c35a1ee131b6b646f26320cad37dd9ed9372b19c"
 dependencies = [
  "ahash",
  "arrow2",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "chrono",
  "comfy-table",
  "either",
@@ -1711,15 +1687,15 @@ dependencies = [
  "regex",
  "smartstring",
  "thiserror",
- "wasm-timer",
+ "version_check",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "polars-error"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1557cd24b1865194bac6979765cfec5e97ecd8af5dcb7858a17b31d1e7fbf70"
+checksum = "66a7d4c872ec0775112a0c527a8d4f74e2ef92f024b795fe7a8b00a21910a5dc"
 dependencies = [
  "arrow2",
  "regex",
@@ -1728,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c44b1c6d7b2c04e459effb93bac050f90762687cb752c534967476c452478a65"
+checksum = "ffbf1693b4f0a87bd576f02c11ebd3d3413199ac919d821c635536144e80affe"
 dependencies = [
  "ahash",
  "arrow2",
@@ -1763,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "polars-json"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eef6b83136b3884ce356ed74b58eeedc81d81b981e901fbd15f16c96a5ff315"
+checksum = "0f1c6c79be2387ffb2f20743d192c11083be0e8bc0adf6d742ce28f1e7ca1142"
 dependencies = [
  "ahash",
  "arrow2",
@@ -1781,12 +1757,12 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494f1e75a035978339b06bdcc4d60523ec347243ac65f11794a7eeaba0507d4e"
+checksum = "707075e6317b047864cccc665d4d27c4936ecdfe54798019bb6dc1d0bc237063"
 dependencies = [
  "ahash",
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "glob",
  "once_cell",
  "polars-arrow",
@@ -1800,13 +1776,14 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-ops"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06dd95bc84a7bf17886670420097c5fb8b88906ebb16653153ce5f0cf71ffd6e"
+checksum = "d4e64910ae597343e3bec8c90c5c5db59ca835e28296dda725718bbc0ce91d15"
 dependencies = [
  "argminmax",
  "arrow2",
@@ -1817,13 +1794,14 @@ dependencies = [
  "polars-core",
  "polars-utils",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-pipe"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff34c8f09c064ab26bc9283c13b6a1571083c30c4c3812301cd84cdd3982a2e0"
+checksum = "d9072be429b07e9282ec24030bc379fe77237aeda78c87a6f566d5d04a9e52e0"
 dependencies = [
  "enum_dispatch",
  "hashbrown 0.14.0",
@@ -1837,13 +1815,14 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-plan"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f0837dac2b7064e04a2a37a2bff20f75a455d23b29f2dd82f0345de62d3bfb"
+checksum = "289b7f2a9139fe13622872860207ef282aea0534578f917e0705a4bab73751aa"
 dependencies = [
  "ahash",
  "arrow2",
@@ -1858,13 +1837,14 @@ dependencies = [
  "regex",
  "smartstring",
  "strum_macros 0.25.1",
+ "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46235f6f67005fff3fd8095b994e86f846b5affd6fc6f36f41099a4dbc27d714"
+checksum = "a238c05921b0bd0064aaa2b9155909c9ff7ed92418fffd3f9f84ba4444531a43"
 dependencies = [
  "arrow2",
  "polars-error",
@@ -1873,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f716671c8e8ed1db6ebdbfcc7ca0c98a599e92c340747c24072b86e8839bed"
+checksum = "d0ae24b6aaa2b2edbee81f2f74cea0e54d71686f121c03d14115297641c6c096"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -1888,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02488938edfbff6efed56a4f90ebd6574ea16a7d32b6dc678134624031f7f3e9"
+checksum = "c8b7d1b30aa65e113d7abd3bd5f3c301df2e033c5fb0d2085c12847b2d9484b3"
 dependencies = [
  "arrow2",
  "atoi",
@@ -1907,17 +1887,19 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f04f6c127b8d20292b4d49b5fb0e47c652875b316274f74f52e77d50f6a459"
+checksum = "e38f1f0fee4bf34bfcb37ba556c69644097270c4fc6a722708d3f7a9e8c0b692"
 dependencies = [
  "ahash",
  "hashbrown 0.14.0",
  "num-traits",
  "once_cell",
+ "polars-error",
  "rayon",
  "smartstring",
  "sysinfo",
+ "version_check",
 ]
 
 [[package]]
@@ -1972,7 +1954,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -2430,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
+checksum = "2eaa1e88e78d2c2460d78b7dc3f0c08dbb606ab4222f9aff36f420d36e307d87"
 dependencies = [
  "log",
 ]
@@ -2723,18 +2705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,31 +2732,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "wide"

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylace"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "SSPL-1.0"
 
@@ -9,7 +9,7 @@ name = "lace"
 crate-type = ["cdylib"]
 
 [dependencies]
-lace = { path = "../lace", version="0.3.0" }
+lace = { path = "../lace", version="0.3.1" }
 lace_utils = { path = "../lace/lace_utils", version="0.1.2" }
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -16,7 +16,7 @@ rand_xoshiro = "0.6.0"
 pyo3 = { version = "0.19", features = ["extension-module"] }
 serde_json = "1.0.91"
 serde_yaml = "0.9.17"
-polars = "0.31"
+polars = "0.32"
 arrow2 = "0.17"
 
 [package.metadata.maturin]

--- a/pylace/Cargo.toml
+++ b/pylace/Cargo.toml
@@ -16,7 +16,7 @@ rand_xoshiro = "0.6.0"
 pyo3 = { version = "0.19", features = ["extension-module"] }
 serde_json = "1.0.91"
 serde_yaml = "0.9.17"
-polars = "0.32"
+polars = "=0.32.0"
 arrow2 = "0.17"
 
 [package.metadata.maturin]

--- a/pylace/pyproject.toml
+++ b/pylace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pylace"
-version = "0.3.1"
+version = "0.3.2"
 description = "A probabalistic programming ML tool for science"
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Specifying to Maturin to build explicitly on each version of Python should be sufficient; all the version wheels will be uploaded into the same artifact location, and everything in that location gets uploaded to PyPi.

I am going to inspect the output of the GH Workflow to be sure, though.