### PR TITLE
fix: Fixed a few pylace bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pylace's `__getitem__` index name to match other accessors.
+- Fixed pylace's `append_column_metadata` to refer to the correct internal function.
+- Pylace will try to use Python's internal conversion for floats in `value_to_datum` conversion. 
+
+
 ## [python-0.3.1] - 2023-08-28
 
 ### Fixed

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "clap",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "enum_dispatch",
  "indicatif",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "flate2",
  "lace_consts",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "dirs",
@@ -1931,7 +1931,7 @@ checksum = "fe7765e19fb2ba6fd4373b8d90399f5321683ea7c11b598c6bbaa3a72e9c83b8"
 
 [[package]]
 name = "pylace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrow2",
  "lace",

--- a/pylace/lace/codebook.py
+++ b/pylace/lace/codebook.py
@@ -360,7 +360,7 @@ class Codebook:
     def append_column_metadata(self, col_metadata: List[_lc.ColumnMetadata]):
         """Append new columns to the codebook."""
         codebook = copy.copy(self)
-        codebook.codebook.append_col_metadata(col_metadata)
+        codebook.codebook.append_column_metadata(col_metadata)
         return codebook
 
     def set_row_names(

--- a/pylace/src/lib.rs
+++ b/pylace/src/lib.rs
@@ -187,7 +187,7 @@ impl CoreEngine {
         let (row_ixs, col_ixs) = ixs.ixs(&self.engine.codebook)?;
 
         let index = polars::series::Series::new(
-            "Index",
+            "index",
             row_ixs
                 .iter()
                 .map(|ix| ix.1.clone())
@@ -1104,6 +1104,7 @@ impl CoreEngine {
         let write_mode = lace::WriteMode {
             overwrite: lace::OverwriteMode::Deny,
             insert: lace::InsertMode::DenyNewColumns,
+            allow_extend_support: true,
             ..Default::default()
         };
         self.engine

--- a/pylace/src/utils.rs
+++ b/pylace/src/utils.rs
@@ -289,9 +289,6 @@ pub(crate) fn vec_to_srs(
             }
         }
         FType::Count => Ok(srs_from_vec!(values, name, u32, Count)),
-        // ftype => Err(PyErr::new::<PyValueError, _>(format!(
-        //     "Simulated unsupported ftype: {ftype:?}"
-        // ))),
     }
     .map(PySeries)
 }
@@ -358,9 +355,6 @@ pub(crate) fn simulate_to_df(
                 }
             }
             FType::Count => Ok(srs_from_simulate!(values, i, name, u32, Count)),
-            // ftype => Err(PyErr::new::<PyValueError, _>(format!(
-            //     "Simulated unsupported ftype: {ftype:?}"
-            // ))),
         }?;
         df.with_column(srs).map_err(|err| {
             PyErr::new::<PyRuntimeError, _>(format!(
@@ -537,10 +531,7 @@ pub(crate) fn value_to_datum(val: &PyAny, ftype: FType) -> PyResult<Datum> {
 
     match ftype {
         FType::Continuous => {
-            let x: f64 = {
-                let f: &PyFloat = val.downcast().unwrap();
-                f.value()
-            };
+            let x: f64 = val.extract().unwrap();
             if x.is_nan() {
                 Ok(Datum::Missing)
             } else {

--- a/pylace/tests/test_index_names.py
+++ b/pylace/tests/test_index_names.py
@@ -1,0 +1,26 @@
+import pytest
+
+from lace.examples import Animals
+
+
+@pytest.fixture(scope="module")
+def animals():
+    animals = Animals()
+    animals.df = animals.df.to_pandas().set_index("id")
+    return animals
+
+
+def test_impute_index_name(animals):
+    """Check impute returns the correct index name."""
+    engine = animals.engine
+
+    predicted = engine.impute(0, rows=engine.index)
+    assert "index" in predicted.columns
+
+
+def test_getitem_index_name(animals):
+    """Check __getitem__ returns the correct index name."""
+    engine = animals.engine
+
+    df = engine["fierce"]
+    assert "index" in df.columns


### PR DESCRIPTION
 - Fixed pylace's `__getitem__` index name to match other accessors.
 - Fixed pylace's `append_column_metadata` to refer to the correct internal function.
 - Pylace will try to use Python's internal conversion for floats in `value_to_datum` conversion.