### PR TITLE
Pin the version of `maturin-action` to a known good version

### DIFF
--- a/.github/workflows/python-build-test.yaml
+++ b/.github/workflows/python-build-test.yaml
@@ -313,7 +313,7 @@ jobs:
           name: wheels
           path: wheels
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@v1.40.2
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:

--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -1904,7 +1904,7 @@ checksum = "fe7765e19fb2ba6fd4373b8d90399f5321683ea7c11b598c6bbaa3a72e9c83b8"
 
 [[package]]
 name = "pylace"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow2",
  "lace",


### PR DESCRIPTION
Using the pinned version of `maturin-action`
  until we can resolve the best way to use it with `download-artifacts`
  https://github.com/PyO3/maturin-action/issues/221