### PR TITLE
feat(pylace): Added `lace.StateTransition.common_transition_sets` for…

### DIFF
--- a/pylace/lace/engine.py
+++ b/pylace/lace/engine.py
@@ -943,7 +943,7 @@ class Engine:
         *,
         timeout: Optional[int] = None,
         checkpoint: Optional[int] = None,
-        transitions: Optional[core.StateTransition] = None,
+        transitions: Optional[Union[str, List[core.StateTransition]]] = None,
         save_path: Optional[Union[str, bytes, PathLike]] = None,
         quiet: bool = False,
     ):
@@ -964,9 +964,14 @@ class Engine:
         checkpoint: int, optional
             The number of iterations between saves. If `save_path` is not
             supplied checkpoints do nothing.
-        transitions: List[StateTransition], optional
-            List of state transitions to perform. If `None` (default) a default
-            set is chosen.
+        transitions: str | List[StateTransition], optional
+            List of state transitions to perform.
+
+            Possible Values:
+            * If `None` (default) a defaultset is chosen.
+            * If one of "sams", "flat", or "fast" to use common sets of
+            transitions.
+            * If a list of `StateTransitions`, then that sequence will be used.
         save_path: pathlike, optional
             Where to save the metadata. If `None` (default) the engine is not
             saved. If `checkpoint` is provided, the `Engine` will be saved at
@@ -985,14 +990,26 @@ class Engine:
 
         >>> from lace import RowKernel, StateTransition
         >>> engine.update(
-        ...     100,
+        ...     5,
         ...     timeout=30,
         ...     transitions=[
         ...         StateTransition.row_assignment(RowKernel.slice()),
         ...         StateTransition.view_alphas(),
         ...     ],
         ... )
+
+        Use a common set of transitions by name, specifically "sams":
+
+        >>> engine.update(
+        ...     5,
+        ...     timeout=30,
+        ...     transitions="sams",
+        ... )
         """
+
+        if isinstance(transitions, str):
+            transitions = utils._get_common_transitions(transitions)
+
         return self.engine.update(
             n_iters,
             timeout=timeout,

--- a/pylace/src/utils.rs
+++ b/pylace/src/utils.rs
@@ -13,7 +13,7 @@ use pyo3::exceptions::{
 };
 use pyo3::prelude::*;
 use pyo3::types::{
-    PyAny, PyBool, PyDict, PyFloat, PyInt, PyList, PySlice, PyString, PyTuple,
+    PyAny, PyBool, PyDict, PyInt, PyList, PySlice, PyString, PyTuple,
 };
 
 use crate::df::{PyDataFrame, PySeries};


### PR DESCRIPTION
… commonly used transitions.

This adds a helper set of commonly used transitions to the `StateTransition` class. For sams, this returns:

```python
>>> import lace
>>> lace.StateTransition.common_transition_sets()["sams"]
[ViewAlphas,
 ColumnAssignment(Sams),
 ViewAlphas,
 ColumnAssignment(Sams),
 ViewAlphas,
 ComponentParams,
 ColumnAssignment(Sams),
 ComponentParams,
 ColumnAssignment(Gibbs),
 ColumnAssignment(Slice),
 ViewAlphas,
 FeaturePriors]
```