### PR TITLE
Publish the new `cli` crate

### DIFF
--- a/.github/workflows/rust-build-test.yaml
+++ b/.github/workflows/rust-build-test.yaml
@@ -218,7 +218,7 @@ jobs:
           test "$DEPLOYING_VERSION" = "$MAIN_VERSION"
       - name: Install dependencies
         run: cargo install cargo-crate
-      - name: Publish Updated Crates to Crates.io
+      - name: Publish Updated Library Crates to Crates.io
         working-directory: lace
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
@@ -240,3 +240,14 @@ jobs:
               cargo publish --token "${CRATES_TOKEN}" -p $PACKAGE_NAME
             fi
           done
+      - name: Publish Updated CLI Crate to Crates.io
+        working-directory: cli
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: |
+          PACKAGE_VERSION=$(tomlq .package.version Cargo.toml)
+          ALREADY_PUBLISHED=$(cargo crate info lace-cli --json --max-versions 100 | jq '[.krate.versions[].num] | any(. == '$PACKAGE_VERSION')')
+          if [ "$ALREADY_PUBLISHED" == 'false' ]
+          then
+            cargo publish --token "${CRATES_TOKEN}" -p lace-cli
+          fi


### PR DESCRIPTION
Added a step so that the `cli` crate will be published as part of publishing