### PR TITLE
Fix citation checker

### DIFF
--- a/.github/workflows/citation.yaml
+++ b/.github/workflows/citation.yaml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Verify CITATION.cff date field
               run: |
-                LAST_RELEASE=$(git describe --abbrev=0  --match="rust-*" --match="python-*" HEAD)
+                LAST_RELEASE=$(git describe --abbrev=0  --match="rust-*" --match="python-*" HEAD~1)
                 LAST_RELEASE_DATE=$(git cat-file -p $LAST_RELEASE:CITATION.cff | cffconvert -f schema.org | jq -r .datePublished)
                 CURRENT_RELEASE_DATE=$(cffconvert -f schema.org | jq -r .datePublished)
-                [[ "$BAR" > "$FOO" ]]
+                [[ ! "$CURRENT_RELEASE_DATE" < "$LAST_RELEASE_DATE" ]]


### PR DESCRIPTION
This is just embarrassing.

I left the test code check in there instead of my real check.
And when I was testing it, it was on a repo that wasn't tagged for a deploy, so I didn't catch the issue with searching from `HEAD`