### PR TITLE
Fix/clarify `CITATION.cff` validation

### DIFF
--- a/.github/workflows/citation.yaml
+++ b/.github/workflows/citation.yaml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - rust-*
-      - python-*
 
 jobs:
     Validate-CITATION-cff:
@@ -33,7 +32,10 @@ jobs:
 
             - name: Verify CITATION.cff date field
               run: |
-                LAST_RELEASE=$(git describe --abbrev=0  --match="rust-*" --match="python-*" HEAD~1)
+                LAST_RELEASE=$(git describe --abbrev=0  --match="rust-*" HEAD~1)
+                echo $LAST_RELEASE
                 LAST_RELEASE_DATE=$(git cat-file -p $LAST_RELEASE:CITATION.cff | cffconvert -f schema.org | jq -r .datePublished)
                 CURRENT_RELEASE_DATE=$(cffconvert -f schema.org | jq -r .datePublished)
-                [[ ! "$CURRENT_RELEASE_DATE" < "$LAST_RELEASE_DATE" ]]
+                echo $CURRENT_RELEASE_DATE $LAST_RELEASE_DATE
+                # Verify that the release date was updated since the last release
+                [[ "$CURRENT_RELEASE_DATE" > "$LAST_RELEASE_DATE" ]]


### PR DESCRIPTION
A small fix to make this job work, but be useful. This currently will throw alerts if the `CITATION.cff` file is incorrect, but will not prevent merges/releases.

I decided to make a few decisions on this:
1. I decided to only validate on Rust releases. This has a few benefits:
   1. It simplifies choosing some of the values. I'm already asserting that the version in the citation file is the Rust Lace version, so this makes that association clearer
   2. It makes it easier to know how to validate certain fields. Since we release Python and Rust separately, but often on the same day, some of the date checking logic is a bit convoluted, since you might sometimes have a previous "release" which still was released on the same day. Only validating on Rust releases solves that problem (unless for some reason we release the Rust version twice on the same day, like in a bug fix or something)
2. I decided not to try to make this a pre-requistie for releasing. Right now this check runs on releases but does not prevent release when it fails. It would be possible to do that but it would require either moving this to the `rust-build-test` workflow or a re-design of that release workflow, and I think the effort would be better spent re-desiging the release workflow to match our current branch-based release process. So I'll hold off until we change our release process, if we do so.