### PR TITLE
Make pylace default transitions hit everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Initializing an engine with a codebook that has a different number of rows than the data will result in an error instead of printing a bunch on nonsense.
+- Pylace default transition sets didn't hit all required transitions
+- Typo in pylace internal `Dimension` class
 
 ## [python-0.6.0] - 2024-01-23
 

--- a/pylace/lace/utils.py
+++ b/pylace/lace/utils.py
@@ -17,7 +17,7 @@ from lace.core import (
 
 class Dimension:
     Rows = 0
-    Colums = 1
+    Columns = 1
 
 
 FN_IS_SYMMETRIC = {
@@ -28,8 +28,8 @@ FN_IS_SYMMETRIC = {
 
 
 FN_DIMENSION = {
-    "mi": Dimension.Colums,
-    "depprob": Dimension.Colums,
+    "mi": Dimension.Columns,
+    "depprob": Dimension.Columns,
     "rowsim": Dimension.Rows,
 }
 
@@ -132,10 +132,10 @@ _COMMON_TRANSITIONS = {
         StateTransition.view_alphas(),
         StateTransition.row_assignment(RowKernel.sams()),
         StateTransition.view_alphas(),
+        StateTransition.row_assignment(RowKernel.slice()),
         StateTransition.component_parameters(),
         StateTransition.column_assignment(ColumnKernel.gibbs()),
-        StateTransition.column_assignment(ColumnKernel.slice()),
-        StateTransition.view_alphas(),
+        StateTransition.state_alpha(),
         StateTransition.feature_priors(),
     ],
     "flat": [
@@ -151,8 +151,12 @@ _COMMON_TRANSITIONS = {
         StateTransition.feature_priors(),
     ],
     "fast": [
+        StateTransition.view_alphas(),
         StateTransition.row_assignment(RowKernel.slice()),
+        StateTransition.component_parameters(),
+        StateTransition.feature_priors(),
         StateTransition.column_assignment(ColumnKernel.slice()),
+        StateTransition.state_alpha(),
     ],
 }
 


### PR DESCRIPTION
I went in to all a slice row kernel in sams, but found that `sams` didn't update state_alpha and `fast` didn't update anything but the row and column reassignment. Fixed.