### PR TITLE
feat(python): Added tqdm handler for `Engine.update` progress bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `DataParseError::CodebookAndDataRowsMismatch` variant for when the number of rows in the codebook and the number of rows in the data do not match.
 - `DataParseError::DataFrameMissingColumn` variant for when a column is in the codebook but not in the initial dataframe.
+- Python's `Engine.update` uses `tqdm.auto` for progress bar reporting.
 
 ### Fixed
 - Initializing an engine with a codebook that has a different number of rows than the data will result in an error instead of printing a bunch on nonsense.

--- a/pylace/docs/requirements.txt
+++ b/pylace/docs/requirements.txt
@@ -7,7 +7,7 @@ commonmark==0.9.1
 hypothesis==6.65.2
 maturin==0.14.10
 mock==1.0.1
-pillow==10.1.0
+pillow==10.2.0
 pytest-cov==4.0.0
 pytest-xdist==3.1.0
 pytest==7.2.0

--- a/pylace/lace/analysis.py
+++ b/pylace/lace/analysis.py
@@ -1,6 +1,5 @@
 """Tools for analysis of probabilistic cross-categorization results in Lace."""
 
-
 import enum
 import itertools as it
 from copy import deepcopy

--- a/pylace/lace/engine.py
+++ b/pylace/lace/engine.py
@@ -1,4 +1,5 @@
 """The main interface to Lace models."""
+
 import itertools as it
 from os import PathLike
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
@@ -56,7 +57,9 @@ class Engine:
     def from_df(
         cls,
         df: Union[pd.DataFrame, pl.DataFrame],
-        codebook: Optional[Union[CodebookBuilder, PathLike, str, Codebook]] = None,
+        codebook: Optional[
+            Union[CodebookBuilder, PathLike, str, Codebook]
+        ] = None,
         n_states: int = 8,
         id_offset: int = 0,
         rng_seed: Optional[int] = None,
@@ -444,7 +447,9 @@ class Engine:
         """
         return self.engine.row_assignments(state_ix)
 
-    def feature_params(self, col: Union[int, str], state_ixs: Optional[List[int]] = None) -> Dict:
+    def feature_params(
+        self, col: Union[int, str], state_ixs: Optional[List[int]] = None
+    ) -> Dict:
         """
         Get the component parameters for a given column.
 
@@ -494,7 +499,10 @@ class Engine:
         if state_ixs is None:
             state_ixs = list(range(self.n_states))
 
-        return {state_ix: self.engine.feature_params(col, state_ix) for state_ix in state_ixs}
+        return {
+            state_ix: self.engine.feature_params(col, state_ix)
+            for state_ix in state_ixs
+        }
 
     def __getitem__(self, ix):
         df = self.engine[ix]
@@ -631,7 +639,9 @@ class Engine:
 
     def append_rows(
         self,
-        rows: Union[pd.Series, pd.DataFrame, pl.DataFrame, Dict[str, Dict[str, object]]],
+        rows: Union[
+            pd.Series, pd.DataFrame, pl.DataFrame, Dict[str, Dict[str, object]]
+        ],
     ):
         """
         Append new rows to the table.
@@ -889,7 +899,9 @@ class Engine:
         └─────────────────┴─────────────────────────────────┘
         """
         if metadata is None:
-            metadata = utils.infer_column_metadata(cols, cat_cutoff=cat_cutoff, no_hypers=no_hypers)
+            metadata = utils.infer_column_metadata(
+                cols, cat_cutoff=cat_cutoff, no_hypers=no_hypers
+            )
 
         self.engine.append_columns(cols, metadata)
 
@@ -1380,7 +1392,9 @@ class Engine:
 
         return out
 
-    def surprisal(self, col: Union[int, str], *, rows=None, values=None, state_ixs=None):
+    def surprisal(
+        self, col: Union[int, str], *, rows=None, values=None, state_ixs=None
+    ):
         r"""
         Compute the surprisal of a values in specific cells.
 
@@ -1498,14 +1512,18 @@ class Engine:
         │ Intelsat 701 ┆ 10.0              ┆ 2.587096  │
         └──────────────┴───────────────────┴───────────┘
         """
-        out = self.engine.surprisal(col, rows=rows, values=values, state_ixs=state_ixs)
+        out = self.engine.surprisal(
+            col, rows=rows, values=values, state_ixs=state_ixs
+        )
 
         if out.shape[1] == 1:
             return out["surprisal"]
         else:
             return out
 
-    def simulate(self, cols, given=None, n: int = 1, include_given: bool = False):
+    def simulate(
+        self, cols, given=None, n: int = 1, include_given: bool = False
+    ):
         """
         Simulate data from a conditional distribution.
 
@@ -1966,7 +1984,9 @@ class Engine:
         srs = self.engine.depprob(col_pairs)
         return utils.return_srs(srs)
 
-    def mi(self, col_pairs: list, n_mc_samples: int = 1000, mi_type: str = "iqr"):
+    def mi(
+        self, col_pairs: list, n_mc_samples: int = 1000, mi_type: str = "iqr"
+    ):
         """
         Compute the mutual information between pairs of columns.
 
@@ -2045,7 +2065,9 @@ class Engine:
             0.005378
         ]
         """
-        srs = self.engine.mi(col_pairs, n_mc_samples=n_mc_samples, mi_type=mi_type)
+        srs = self.engine.mi(
+            col_pairs, n_mc_samples=n_mc_samples, mi_type=mi_type
+        )
         return utils.return_srs(srs)
 
     def rowsim(

--- a/pylace/src/update_handler.rs
+++ b/pylace/src/update_handler.rs
@@ -1,0 +1,139 @@
+use std::io::Write;
+/// Update Handler and associated tooling for `CoreEngine.update` in Python.
+use std::sync::{Arc, Mutex};
+
+use lace::cc::state::State;
+use lace::update_handler::UpdateHandler;
+use lace::EngineUpdateConfig;
+use pyo3::{pyclass, IntoPy, Py, PyAny};
+
+/// Python version of `EngineUpdateConfig`.
+#[derive(Clone, Debug)]
+#[pyclass(frozen, get_all)]
+pub struct PyEngineUpdateConfig {
+    /// Maximum number of iterations to run.
+    pub n_iters: usize,
+    /// Number of iterations after which each state should be saved
+    pub checkpoint: Option<usize>,
+    /// Number of states
+    pub n_states: usize,
+}
+
+/// An `UpdateHandler` which wraps a Python Object.
+#[derive(Debug, Clone)]
+pub struct PyUpdateHandler {
+    handler: Arc<Mutex<Py<PyAny>>>,
+}
+
+impl PyUpdateHandler {
+    /// Create a new `PyUpdateHandler` from a Python Object
+    pub fn new(handler: Py<PyAny>) -> Self {
+        Self {
+            handler: Arc::new(Mutex::new(handler)),
+        }
+    }
+}
+
+macro_rules! pydict {
+    ($py: expr, $($key:tt : $val:expr),* $(,)?) => {{
+
+        let map = pyo3::types::PyDict::new($py);
+        $(
+            let _ = map.set_item($key, $val.into_py($py))
+                .expect("Should be able to set item in PyDict");
+        )*
+        map
+    }};
+}
+
+macro_rules! call_pyhandler_noret {
+    ($self: ident, $func_name: tt, $($key: tt : $val: expr),* $(,)?) => {{
+        let handler = $self
+            .handler
+            .lock()
+            .expect("Should be able to get a lock for the PyUpdateHandler");
+
+        ::pyo3::Python::with_gil(|py| {
+            let kwargs = pydict!(
+                py,
+                $($key: $val),*
+            );
+
+            handler
+                .call_method(py, $func_name, (), kwargs.into())
+                .expect("Expected python call_method to return successfully");
+        })
+    }};
+}
+
+macro_rules! call_pyhandler_ret {
+    ($self: ident, $func_name: tt, $($key: tt : $val: expr),* $(,)?) => {{
+        let handler = $self
+            .handler
+            .lock()
+            .expect("Should be able to get a lock for the PyUpdateHandler");
+
+        ::pyo3::Python::with_gil(|py| {
+            let kwargs = pydict!(
+                py,
+                $($key: $val),*
+            );
+
+            handler
+                .call_method(py, $func_name, (), kwargs.into())
+                .expect("Expected python call_method to return successfully")
+                .extract(py)
+                .expect("Failed to extract expected type")
+        })
+    }};
+}
+
+impl UpdateHandler for PyUpdateHandler {
+    fn global_init(&mut self, config: &EngineUpdateConfig, states: &[State]) {
+        call_pyhandler_noret!(
+            self,
+            "global_init",
+            "config": PyEngineUpdateConfig {
+                n_iters: config.n_iters,
+                checkpoint: config.checkpoint,
+                n_states: states.len(),
+            }
+        );
+    }
+
+    fn new_state_init(&mut self, state_id: usize, _state: &State) {
+        call_pyhandler_noret!(
+            self,
+            "new_state_init",
+            "state_id": state_id,
+        );
+    }
+
+    fn state_updated(&mut self, state_id: usize, _state: &State) {
+        call_pyhandler_noret!(
+            self,
+            "state_updated",
+            "state_id": state_id,
+        );
+    }
+
+    fn state_complete(&mut self, state_id: usize, _state: &State) {
+        call_pyhandler_noret!(
+            self,
+            "state_complete",
+            "state_id": state_id,
+        );
+    }
+
+    fn stop_engine(&self) -> bool {
+        call_pyhandler_ret!(self, "stop_engine",)
+    }
+
+    fn stop_state(&self, _state_id: usize) -> bool {
+        call_pyhandler_ret!(self, "stop_state",)
+    }
+
+    fn finalize(&mut self) {
+        call_pyhandler_noret!(self, "finalize",)
+    }
+}

--- a/pylace/tests/example_test.py
+++ b/pylace/tests/example_test.py
@@ -1,4 +1,5 @@
 """Check the basics of the example datasets."""
+
 from numpy.testing import assert_almost_equal
 
 from lace import examples

--- a/pylace/tests/test_self_referencing.py
+++ b/pylace/tests/test_self_referencing.py
@@ -1,4 +1,5 @@
 """Tests whether engine functions work with various engine outputs."""
+
 import random
 
 import polars as pl


### PR DESCRIPTION
The API for the Python binding did not change outside the `lace.core` module.

This allows for a progress bar to be called and updated like `Lace::UpdateHandler` in `lace.core.update`. Here, the default is to use `tqdm.auto`.

This addresses #173.