### PR TITLE
feat!(pylace): Return `PyResults` for several methods vs unwrap

### DIFF
--- a/pylace/Cargo.lock
+++ b/pylace/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "lace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dirs",
  "indexmap",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "lace_cc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "enum_dispatch",
  "itertools",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lace_consts",
  "lace_data",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "lace_data"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "lace_utils",
  "serde",
@@ -599,7 +599,7 @@ dependencies = [
 
 [[package]]
 name = "lace_geweke"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "indicatif",
  "lace_stats",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "lace_metadata"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bincode",
  "hex",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "lace_stats"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "itertools",
  "lace_consts",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "lace_utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rand",
  "rayon",
@@ -1345,7 +1345,7 @@ checksum = "fe7765e19fb2ba6fd4373b8d90399f5321683ea7c11b598c6bbaa3a72e9c83b8"
 
 [[package]]
 name = "pylace"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lace",
  "lace_utils",

--- a/pylace/src/component.rs
+++ b/pylace/src/component.rs
@@ -73,7 +73,10 @@ impl CategoricalParams {
             _ => format!(
                 "[{}, ..., {}]",
                 self.weights[0],
-                self.weights.last().unwrap()
+                self.weights
+                    .last()
+                    .map(|x| x.to_string())
+                    .unwrap_or_else(|| "-".to_string())
             ),
         };
 

--- a/pylace/src/df.rs
+++ b/pylace/src/df.rs
@@ -166,6 +166,8 @@ pub(crate) fn to_py_array(
     Ok(array.to_object(py))
 }
 
+// TODO: When https://github.com/PyO3/pyo3/issues/1813 is solved, implement a
+// failable version.
 impl IntoPy<PyObject> for PySeries {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let s = self.0.rechunk();
@@ -181,6 +183,8 @@ impl IntoPy<PyObject> for PySeries {
     }
 }
 
+// TODO: When https://github.com/PyO3/pyo3/issues/1813 is solved, implement a
+// failable version.
 impl IntoPy<PyObject> for PyDataFrame {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let pyseries = self

--- a/pylace/src/update_handler.rs
+++ b/pylace/src/update_handler.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 /// Update Handler and associated tooling for `CoreEngine.update` in Python.
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Removed several unwraps and replaced them with `PyResult` returns. Some could not be removed due to PyO3's limitation to non-failable type conversions https://github.com/PyO3/pyo3/issues/1813.