### PR TITLE
feat(python)!: Updated dependencies for pylace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated dependencies for pylace:
+    `pandas`: 1.3 -> 2.2
+    `pyarrow`: 14.0 -> 15.0
+
 ## [python-0.7.0] - 2024-02-07
 
 ### Added

--- a/pylace/pyproject.toml
+++ b/pylace/pyproject.toml
@@ -35,14 +35,14 @@ maintainers = [
 
 dependencies = [
     'numpy ~= 1.26',
-    'matplotlib ~= 3.8.2',
+    'matplotlib ~= 3.8',
     'seaborn ~= 0.13',
-    'pandas ~= 1.3',
-    'polars ~= 0.20.5',
+    'pandas ~= 2.2',
+    'polars ~= 0.20',
     'scipy ~= 1.11',
     'plotly ~= 5.18',
-    'tqdm ~= 4.66.1',
-    'pyarrow ~= 14.0.0'
+    'tqdm ~= 4.66',
+    'pyarrow ~= 15.0'
 ]
 
 [project.urls]
@@ -71,6 +71,7 @@ target-version = "py37"
 line-length = 100
 fix = true
 
+[lint]
 # leave my Greeks alone!
 allowed-confusables = ["ρ", "α"]
 
@@ -119,13 +120,13 @@ ignore = [
   "SIM114",
 ]
 
-[tool.ruff.pycodestyle]
+[lint.ruff.pycodestyle]
 max-doc-length = 100
 
-[tool.ruff.flake8-tidy-imports]
+[lint.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.flake8-type-checking]
+[lint.ruff.flake8-type-checking]
 strict = true
 
 [tool.black]


### PR DESCRIPTION
Updated dependencies:
	* `pandas`: 1.3 -> 2.2
	* `pyarrow`: 14.0 -> 15.0
	* Removed unnecessary version specificity.