### PR TITLE
Updated `mio` locked package to protect against CVE-2024-27308

### DIFF
--- a/book/lace_preprocess_mdbook_yaml/Cargo.lock
+++ b/book/lace_preprocess_mdbook_yaml/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "lace_codebook"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "lace_consts",
  "lace_data",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "lace_data"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "lace_utils",
  "serde",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "lace_stats"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "itertools",
  "lace_consts",
@@ -1082,9 +1082,10 @@ dependencies = [
 
 [[package]]
 name = "lace_utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rand",
+ "rayon",
 ]
 
 [[package]]
@@ -1280,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -2200,9 +2201,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rv"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad4c180111696893363158f59ee1b15500947365270b7460a432fc207f926bf"
+checksum = "7a650cc227f4eb01b043fb7580097d6830c688a8f33cd9eabbced2026d11abf5"
 dependencies = [
  "doc-comment",
  "lru",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",

--- a/lace/Cargo.lock
+++ b/lace/Cargo.lock
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
This vulnerability specifically affects Windows users, and particularly Tokio users on Windows; so the threat exposure is probably low. But it doesn't hurt to avoid it