### PR TITLE
Restored plotly to the mdbook

### DIFF
--- a/book/theme/index.hbs
+++ b/book/theme/index.hbs
@@ -18,10 +18,17 @@
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff">
+        <script src="https://cdn.plot.ly/plotly-2.18.0.min.js"></script>
         <script type="module">
           import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
           mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
         </script>
+
+        <style>
+            .plotly-graph-div {
+                aspect-ratio: 1 / 1;
+            }
+        </style>
 
         {{#if favicon_svg}}
         <link rel="icon" href="{{ path_to_root }}favicon.svg">


### PR DESCRIPTION
It looks like when I was regenerating the MDBook pages, I missed the addition of Plotly as a dependency. This should fix that.

